### PR TITLE
 feat: buffers, directives: Add docs for all buffers and directives for configuring buffers

### DIFF
--- a/src/content/docs/reference/Buffers/colortex.mdx
+++ b/src/content/docs/reference/Buffers/colortex.mdx
@@ -4,9 +4,46 @@ description: ColorTex
 sidebar:
   label: ColorTex
   order: 1
-  badge:
-    text: Unfinished
-    variant: caution
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+
+### `uniform sampler2D colortexN;`
+### `layout (<format>) uniform image2D colorimgN;`
+
+There are 16 color attachements available through the `colortex0` through `colortex15` samplers. These samplers can be read from any program, and can be written to from the fragment stage of any [`begin`](/reference/programs/begin), [`prepare`](/reference/programs/prepare), [`gbuffers`](/reference/programs/gbuffers), [`deferred`](/reference/programs/deferred), or [`composite`](/reference/programs/composite) program. 
+
+*Note*: The `final.fsh` program appears to write to `colortex0`, however it actually writes to a display buffer with the resolution of the Minecraft window and `RGBA` format (usually equates to `RGBA8`) regardless of the size or format of `colortex0`. If `colortex0` is set to non-clearing, any output written by `final.fsh` will not impact `colortex0`.
+
+#### Writing to ColorTex buffers
+Any [`begin`](/reference/programs/begin), [`prepare`](/reference/programs/prepare), [`gbuffers`](/reference/programs/gbuffers), [`deferred`](/reference/programs/deferred), or [`composite`](/reference/programs/composite) program can write to a colortex buffer, the buffers to write to can be selected with the [`RENDERTARGETS`](/reference/directives/rendertargets) or [`DRAWBUFFERS`](/reference/directives/drawbuffers) directive.
+
+Additionally, you can read and write to the first 6 colortex buffer in Optifine or any colortex buffer in Iris using `colorimgN` where `N` is replaced with the colortex index. This is the only way to write to colortex buffers from compute shaders, but also works in any program. For more information on image load/store, see the [Khronos Wiki](https://www.khronos.org/opengl/wiki/Image_Load_Store).
+
+#### Buffer size
+These buffers default to the display resolution, although this can be configured with the [`size.buffer`](/reference/directives/buffer_size) define in shaders.properties. However, changing the buffer size will prevent any [`gbuffer`](/reference/programs/gbuffers) program from writing to the texture.
+
+#### Buffer format/precision
+All buffers default to `RGBA` format (which is `RGBA8` on most systems), but this can be configured as described in the [Texture Formats](/reference/buffers/texture_format) section.
+
+#### Buffer clear
+By default all buffers clear their values after each frame to solid black (all 0s including alpha), except `colortex0` which clears to the [`fogColor`](/reference/uniforms/general/fogcolor) with 1.0 alpha, and `colortex1` which clears to solid white (all 1s including alpha). This clearing behavior can be configured with the [`colortexNClear`](/reference/directives/buffer_clear) directive, and the clear color can be configured with the [`colortexNClearColor`](/reference/directives/buffer_clear_color) directive.
+
+#### Ping-Pong buffers
+Each colortex sampler actually contains two buffers, which allows you to read and write to the same buffer in a composite/deferred pass. The buffer flipping behavior can be controlled with the [`flip.<program>.<buffer>`](/reference/directives/buffer_flip) directive.
+
+#### Legacy Aliases
+The first 8 colortex buffers have legacy aliases, although their names are often confusing and their use is not recommended. Except as noted below, either name can be used interchangably. The names are as follows:
+
+| colortex name | legacy name |
+| ------------- | ----------- |
+| colortex0     | gcolor      |
+| colortex1     | gdepth      |
+| colortex2     | gnormal     |
+| colortex3     | composite   |
+| colortex4     | gaux1       |
+| colortex5     | gaux2       |
+| colortex6     | gaux3       |
+| colortex7     | gaux4       |
+
+*Note: if `gdepth` is defined anywhere in the shader and the texture format for `colortex1`/`gdepth` is `RGBA` (or not specifically set by the shader), Iris will upgrade the format to `RGBA32F`. This represents legacy behavior, where `gdepth` was used to store depth values.*

--- a/src/content/docs/reference/Buffers/custom.mdx
+++ b/src/content/docs/reference/Buffers/custom.mdx
@@ -4,9 +4,45 @@ description: Custom Buffers
 sidebar:
   label: Custom Buffers
   order: 2
-  badge:
-    text: Unfinished
-    variant: caution
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+
+### `texture.<stage>.<bufferName> = <path>`
+This directive allows a custom texture to be bound to an existing sampler (such as a [colortex](/reference/buffers/colortex) sampler). This allows the shader to access external textures or specific textures from the resource pack.
+
+Textures can be loaded from the shader pack files by replacing `<path>` with the file path to the texture relative to the `shaders` folder. For example `texture.composite.colortex5 = textures/perlin.png` would load `perlin.png` from the `shaders/textures` folder. `.png` and `.jpg` formats are supported.
+
+Textures can also be loaded from the resource pack by replacing `<path>` with `minecraft:` followed by the path in the resourcepack (or vanilla files) of the texture. For example, `texture.deferred.colortex7 = minecraft:textures/block/dirt.png` will load the dirt texture from the resource pack or vanilla assets.
+
+Finally, dynamic textures can be loaded, such as the lightmap and texture atlases. For example, the lightmap can be loaded with `texture.prepare.colortex2 = minecraft:dynamic/lightmap_1`, and the texture atlas can be loaded with `texture.composite.colortex9 = minecraft:textures/atlas/blocks.png`.
+
+For any resource pack or atlas texture, the normal or specular versions of the textuers (if they exist) can be loaded by appending the `_n` or `_s` suffix respectively. For example, `texture.deferred.colortex2 = minecraft:textures/atlas/blocks_s.png` loads the specular block atlas.
+
+Replace `<stage>` with the stage of programs which the texture will be bound in. During that stage, the [colortex](/reference/buffers/colortex) sampler specified with `<bufferName>` will sample the custom texture rather than the [colortex](/reference/buffers/colortex) buffer. The following options are available for `<stage>`:
+
+| name         | description                                                                                     |
+|--------------|-------------------------------------------------------------------------------------------------|
+| `setup`      | [`setup`](/reference/prorgams/setup) programs, exclusive to Iris                                |
+| `begin`      | [`begin`](/reference/programs/begin) programs, exclusive to Iris                                |
+| `shadowcomp` | [`shadowcomp`](/reference/programs/shadow_comp) programs                                        |
+| `prepare`    | [`prepare`](/reference/programs/prepare) programs                                               |
+| `gbuffers`   |  [`gbuffers`](/reference/programs/gbuffers) and [`shadow`](/reference/programs/shadow) programs |
+| `deferred`   | [`deferred`](/reference/programs/deferred) programs                                             |
+| `composite`  | [`composite`](/reference/programs/composite) and [`final`](/reference/programs/final) programs  |
+
+
+# Raw Textures
+### `texture.<stage>.<bufferName> = <path> <type> <internalFormat> <dimensions> <pixelFormat> <pixelType>`
+Raw textures (i.e. unencoded binary files) can also be loaded using the above syntax.
+- `<type>` can be one of the following: `TEXTURE_1D`, `TEXTURE_2D`, `TEXTURE_3D`, or `TEXTURE_RECTANGLE`.
+- Replace `<internalFormat>` with the [texture format](/reference/buffers/texture_format).
+- Replace `<dimensions>` with the fixed size dimensions of the texture (the number of components depends on the type).
+- Replace `<pixelFormat>` with the pixel format described in the "Pixel Formats" section of the [texture format section](/reference/buffers/texture_format).
+- Replace `<pixelType>` with the pixel type described in the "Pixel Types" section of the [texture format section](/reference/buffers/texture_format).
+
+
+# Iris Enhanced Custom Textures
+### `customTexture.<name> = <path>`
+### `customTexture.<name> = <path> <type> <internalFormat> <dimensions> <pixelFormat> <pixelType>`
+Iris adds support for the `customTexture` directive, which allows the shader dev to use a different sampler instead of overriding an existing sampler. This allows creation of a sampler of (mostly) any name, which replaces `<name>` in the directive and is used in the shader code. Otherwise the syntax of the enhanced custom textures are identical to standard custom textures.

--- a/src/content/docs/reference/Buffers/depthtex.mdx
+++ b/src/content/docs/reference/Buffers/depthtex.mdx
@@ -1,0 +1,21 @@
+---
+title: DepthTex
+description: DepthTex
+sidebar:
+  label: DepthTex
+  order: 1
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+### `uniform sampler2D depthtexN;`
+
+There are three samplers for accessing the depth buffer.
+- `depthtex0` includes all geometry
+- `depthtex1` excludes transparent geometry
+- `depthtex2` excludes transparent and heldheld geometry
+
+These buffers are written to by [`gbuffers`](/reference/programs/gbuffers) programs, and store the screenspace z coordinate at each pixel. These buffers only store information in a single channel, the red component. The depth buffer precision is hardware/driver dependent, however most hardware uses either 24-bit or 32-bit precision. The depth buffers are the same resolution as the Minecraft window and this cannot be changed.
+
+### Legacy Alias
+`depthtex0` can be accessed through the legacy alias `gdepthtex`.

--- a/src/content/docs/reference/Buffers/noisetex.mdx
+++ b/src/content/docs/reference/Buffers/noisetex.mdx
@@ -1,0 +1,11 @@
+---
+title: NoiseTex
+description: NoiseTex
+sidebar:
+  label: NoiseTex
+  order: 1
+---
+
+### `uniform sampler2D noisetex;`
+
+This buffer stores a generated RGB white noise texture. The resolution of this texture can be configured with the `const int noiseTextureResolution` constant, and defaults to 256x256. The texture is always square, meaning its width and height are equal.

--- a/src/content/docs/reference/Buffers/shadowcolor.mdx
+++ b/src/content/docs/reference/Buffers/shadowcolor.mdx
@@ -1,0 +1,37 @@
+---
+title: ShadowColor
+description: ShadowColor
+sidebar:
+  label: ShadowColor
+  order: 1
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+### `uniform sampler2D shadowcolorN;`
+### `layout (<format>) uniform image2D shadowcolorimgN;`
+
+The shadow pass supplies two color attachments for outputing color/data, `shadowcolor0` and `shadowcolor1`. These samplers can be read from any program, and can be written to from the fragment stage of the [`shadow`](/reference/programs/shadow) and [`shadowcomp`](/reference/programs/shadow_comp) programs. 
+
+#### Writing to ShadowColor buffers
+Any [`shadow`](/reference/programs/shadow) or [`shadowcomp`](/reference/programs/shadow_comp) program can write to a shadowcolor buffer, the buffers to write to can be selected with the [`RENDERTARGETS`](/reference/directives/rendertargets) or [`DRAWBUFFERS`](/reference/directives/drawbuffers) directive.
+
+Additionally, you can read and write to `shadowcolor0` and `shadowcolor1` using the image bindings `shadowcolorimg0` through `shadowcolorimg1` in any program. This is the only way to write to shadowcolor buffers from compute shaders. For more information on image load/store, see the [Khronos Wiki](https://www.khronos.org/opengl/wiki/Image_Load_Store).
+
+#### Buffer size
+These buffers default to the shadow pass resolution, which can be controlled with the `shadowMapResolution` constant.
+
+#### Buffer format/precision
+These buffers default `RGBA` format (which defaults to `RGBA8` on most systems), but this can be configured as described in the [Texture Formats](/reference/buffers/texture_format) section.
+
+#### Buffer clear
+By default these buffers clear their values after each frame to solid white (all 1s including alpha) This clearing behavior can be configured with the [`shadowcolorNClear`](/reference/directives/buffer_clear) directive, and the clear color can be configured with the [`shadowcolorNClearColor`](/reference/directives/buffer_clear_color) directive.
+
+#### Ping-Pong buffers
+Each colortex sampler actually contains two buffers, which allows you to read and write to the same buffer in a composite/deferred pass. The buffer flipping behavior can be controlled with the [`flip.<program>.<buffer>`](/reference/directives/buffer_flip) directive.
+
+#### Legacy Alias
+The sampler `shadowcolor0` is also accessible through the legacy `shadowcolor` alias.
+
+#### Extended Shadowcolor
+The [Feature Flag](/reference/directives/flags) `HIGHER_SHADOWCOLOR` enables additional shadowcolor buffers, `shadowcolor2` through `shadowcolor7`. These are identical to the other shadowcolor buffers outside of their name.

--- a/src/content/docs/reference/Buffers/shadowtex.mdx
+++ b/src/content/docs/reference/Buffers/shadowtex.mdx
@@ -1,0 +1,22 @@
+---
+title: ShadowTex
+description: ShadowTex
+sidebar:
+  label: ShadowTex
+  order: 1
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+### `uniform sampler2D shadowtexN;`
+
+There are two samplers for accessing the shadow depth buffer.
+- `shadowtex0` includes all geometry
+- `shadowtex1` excludes transparent geometry
+
+These buffers are written to by [`shadow`](/reference/programs/shadow) program, which renders the scene from the perspective of the sun or moon.
+
+These buffers only store information in a single channel, the red component. The shadow buffer precision is hardware/driver dependent, however most hardware uses either 24-bit or 32-bit precision. The resolution of the shadow pass can be controlled with the `shadowMapResolution` constant.
+
+#### Legacy Aliases
+The alias `waterShadow` points to the same buffer as `shadowtex0`. If `waterShadow` is present anywhere in the code, then the alias `shadow` will point to the same buffer as `shadowtex1`, otherwise it will point to the buffer `shadowtex0`.

--- a/src/content/docs/reference/Buffers/texture_format.mdx
+++ b/src/content/docs/reference/Buffers/texture_format.mdx
@@ -1,0 +1,122 @@
+---
+title: Texture Format
+description: Texture Format
+sidebar:
+  label: Texture Format
+  order: 3
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Color attachments, such as [colortex](/reference/buffers/colortex) and [shadowcolor](/reference/buffers/shadowcolor) buffers, store values in a specific format. The default format is `RGBA` (which equates to `RGBA8` on most systems), however a shader pack can specify the format and precision of each color attachment.
+
+The format for any color attachement can be set using the [\<bufferName\>Format](/reference/directives/buffer_format) directive.
+
+The available texture formats and their meanings are described below:
+
+## Normalized
+
+Normalized buffers can store "floating point" values in a fixed range, between 0.0 and 1.0 (inclusive).  The values are not actually stored as floating point internally, but as an integer value. However, the result is converted to a floating point during read/write to a color attachment using a normalized format, so the shader will read/write floating point values to the attachments, however any values outside of the range will be clamped to fit in the range.
+
+| 8-bit | 16-bit | mixed    |
+| ----- | ------ | -------- |
+| R8    | R16    | RGB5_A1  |
+| RG8   | RG16   | RGB10_A2 |
+| RGB8  | RGB16  |          |
+| RGBA8 | RGBA16 |          |
+
+## Signed Normalized
+
+Signed Normalized buffers are identical to normalized buffers, however the range they can represent is expanded to -1 to 1 inclusive, allowing them to store negative values.
+
+| 8-bit       | 16-bit       |
+| ----------- | ------------ |
+| R8_SNORM    | R16_SNORM    |
+| RG8_SNORM   | RG16_SNORM   |
+| RGB8_SNORM  | RGB16_SNORM  |
+| RGBA8_SNORM | RGBA16_SNORM |
+
+## Floating Point
+
+Floating point buffers allow the attachment to store full floating point values. They are only available with larger than default precision due to the increased storage needed for floating point values. However they offer a significantly larger range of values, allowing the storing of HDR values.
+
+| 16-bit  | 32-bit  | mixed          |
+| ------- | ------- | -------------- |
+| R16F    | R32F    | RGB9_E5        |
+| RG16F   | RG32F   | R11F_G11F_B10F |
+| RGB16F  | RGB32F  |                |
+| RGBA16F | RGBA32F |                |
+
+The `RGB9_E5` format uses a 5-bit exponent for all three terms (R, G, and B), where each component has a 9 bit mantissa. This allows significantly more precision than the `R11F_G11F_B10F`, which only has 6 to 5 bits of precision per component, however `R11F_G11F_B10F` has individual exponents for each component. For more information on these format types, see the [OpenGL Wiki](https://www.khronos.org/opengl/wiki/Small_Float_Formats)
+
+## Signed Integer
+
+Signed Integer buffers allow storing signed integers, just like the tin says. These are standard two's complement integers, which means they can store negative values.
+
+| 8-bit  | 16-bit  | 32-bit  |
+| ------ | ------- | ------- |
+| R8I    | R16I    | R32I    |
+| RG8I   | RG16I   | RG32I   |
+| RGB8I  | RGB16I  | RGB32I  |
+| RGBA8I | RGBA16I | RGBA32I |
+
+## Unsigned Integer
+
+Unsigned Integer buffers allow storing of unsigned integers, which will not be interpreted as negative values (although they can be cast to signed integers after being read). As such they do not directly allow the storage of negative integers, but have double the range of their signed cousins in the positive domain.
+
+| 8-bit   | 16-bit   | 32-bit   |
+| ------- | -------- | -------- |
+| R8UI    | R16UI    | R32UI    |
+| RG8UI   | RG16UI   | RG32UI   |
+| RGB8UI  | RGB16UI  | RGB32UI  |
+| RGBA8UI | RGBA16UI | RGBA32UI |
+
+
+## Pixel Formats
+Pixel formats are used to describe the layout of the data in a texture. These are used when defining custom textures and custom images. The following formats are available:
+
+| name   |
+|--------|
+| `RED`  |
+| `RG`   |
+| `RGB`  |
+| `BGR`  |
+| `RGBA` |
+| `BGRA` |
+
+When using integer buffers, append `_INTEGER` to the format:
+
+| name           |
+|----------------|
+| `RED_INTEGER`  |
+| `RG_INTEGER`   |
+| `RGB_INTEGER`  |
+| `BGR_INTEGER`  |
+| `RGBA_INTEGER` |
+| `BGRA_INTEGER` |
+
+## Pixel Types
+Pixel types are used to describe the format/memory representation of each component of the data in a texture. These are used when defining custom textures and images. The following formats are available:
+
+| name                          |
+|-------------------------------|
+| `BYTE`                        |
+| `SHORT`                       |
+| `INT`                         |
+| `HALF_FLOAT`                  |
+| `FLOAT`                       |
+| `UNSIGNED_BYTE`               |
+| `UNSIGNED_BYTE_3_3_2`         |
+| `UNSIGNED_BYTE_2_3_3_REV`     |
+| `UNSIGNED_SHORT`              |
+| `UNSIGNED_SHORT_5_6_5`        |
+| `UNSIGNED_SHORT_5_6_5_REV`    |
+| `UNSIGNED_SHORT_4_4_4_4`      |
+| `UNSIGNED_SHORT_4_4_4_4_REV`  |
+| `UNSIGNED_SHORT_5_5_5_1`      |
+| `UNSIGNED_SHORT_1_5_5_5_REV`  |
+| `UNSIGNED_INT`                |
+| `UNSIGNED_INT_8_8_8_8`        |
+| `UNSIGNED_INT_8_8_8_8_REV`    |
+| `UNSIGNED_INT_10_10_10_2`     |
+| `UNSIGNED_INT_2_10_10_10_REV` |

--- a/src/content/docs/reference/Directives/buffer_clear.mdx
+++ b/src/content/docs/reference/Directives/buffer_clear.mdx
@@ -1,0 +1,17 @@
+---
+title: Buffer Clear
+description: Buffer Clear
+sidebar:
+  label: Buffer Clear
+  order: 3
+---
+
+### `const bool <bufferName>Clear = false;`
+
+#### Location: any glsl shader file
+
+This Clear directive allows a shader pack to disable clearing for a [colortex](/reference/buffers/colortex) or [shadowcolor](/reference/buffers/shadowcolor) color attachment. This means that the values written to the texture will be retained through the next frame instead of being cleared after every frame. The value the buffer is cleared to is controlled by the [`<bufferName>ClearColor`](/reference/directives/buffer_clear_color) directive.
+
+Replace `<bufferName>` with the name of a sampler (e.g. `colortex2` or `shadowcolor0`).
+
+This directive only needs to be defined once in the shader pack, and can be defined in (mostly) any shader file.

--- a/src/content/docs/reference/Directives/buffer_clear_color.mdx
+++ b/src/content/docs/reference/Directives/buffer_clear_color.mdx
@@ -1,0 +1,21 @@
+---
+title: Buffer Clear Color
+description: Buffer Clear Color
+sidebar:
+  label: Buffer Clear Color
+  order: 3
+---
+
+### `const bool <bufferName>ClearColor = vec4(<value>);`
+
+#### Location: any glsl shader file
+
+The ClearColor directive is used when clearing is enabled, and it defines the value stored in a [colortex](/reference/buffers/colortex) or [shadowcolor](/reference/buffers/shadowcolor) buffer after the clear operation (see [buffer clear](/reference/directives/buffer_clear)).
+
+Replace `<bufferName>` with the name of a sampler (e.g. `colortex2` or `shadowcolor0`).
+
+By default, all [colortex](/reference/buffers/colortex) buffers are cleared to 0s (black), except `colortex0`, which is cleared to the current fog color, and `colortex1`, which is cleared to white. All [shadowcolor](/reference/buffers/shadowcolor) buffers are cleared with white by default. This directive allows changing this clear color for each attachment individually.
+
+Currently the only option for setting clear color is with a vec4 value. If the buffer stores less than four components, the leftmost components will be used and the rest discarded. For integer buffers, the bits of the float value will be intepreted as a 32-bit integer (not converted, but directly intepreted bitwise) and used as the clear color. For 16 and 8 bit buffers, any value outside the range will be clamped to the maximum or minimum value depending if it's beyond the positive or negative bound.
+
+This directive only needs to be defined once in the shader pack, and can be defined in (mostly) any shader file.

--- a/src/content/docs/reference/Directives/buffer_flip.mdx
+++ b/src/content/docs/reference/Directives/buffer_flip.mdx
@@ -1,0 +1,15 @@
+---
+title: Buffer Flip
+description: Buffer Flip
+sidebar:
+  label: Buffer Flip
+  order: 3
+---
+
+### `flip.<program>.<bufferName>=<true|false>`
+
+#### Location: shaders.properties
+
+For each color attachment sampler, there is actually two buffers, the "main" and "alt" buffers. [`gbuffers`](/reference/programs/gbuffers) and [`shadow`](/reference/programs/shadow) programs read from the "main" buffer and write to the "main" buffer, which means that reading to and writing from the same buffer will cause artifacting. [`begin`](/reference/programs/begin), [`shadowcomp`](/reference/programs/shadow_comp), [`prepare`](/reference/programs/prepare), [`deferred`](/reference/programs/deferred), and [`composite`](/reference/programs/composite) passes however read from the "main" buffer and write to the "alt" buffer, allowing them to read and write to the same buffer, and after that program the "main" and "alt" buffers are swapped so data written by the current program is read by the next program.
+
+This behavior can be controlled with the `flip.<program>.<bufferName>` directive. Replace `<program>` with the program name (i.e. `composite2`), `<bufferName>` with the sampler name (i.e. `colortex5`), setting the value to `false` will disable the buffer flip that would happen before the start of that program. The default behavior is for buffer flipping to be enabled for all programs.

--- a/src/content/docs/reference/Directives/buffer_format.mdx
+++ b/src/content/docs/reference/Directives/buffer_format.mdx
@@ -1,0 +1,15 @@
+---
+title: Buffer Format
+description: Buffer Format
+sidebar:
+  label: Buffer Format
+  order: 3
+---
+
+### `const int <bufferName>Format = <format>;`
+
+#### Location: any glsl shader file
+
+This directive allows a shader pack to specify the format and precision of a [colortex](/reference/buffers/colortex) or [shadowcolor](/reference/buffers/shadowcolor) color attachment. Replace `<bufferName>` with the name of the color attachment (i.e. `colortex2`, `shadowcolor0`, etc) and `format` with the format as described in the [Texture Formats](/reference/buffers/texture_format) section.
+
+This directive only needs to be defined once in the shader pack, can can be defined in (mostly) any shader file. Because the format names are not defined as part of glsl, the directive must either be put in a block comment, or the format name must be otherwise manually defined to any value to avoid compilation errors. Do not put the directive in a single line comment, or have any other text in the line of the directive, as this may cause it to not be detected properly.

--- a/src/content/docs/reference/Directives/buffer_size.mdx
+++ b/src/content/docs/reference/Directives/buffer_size.mdx
@@ -1,0 +1,15 @@
+---
+title: Buffer Size
+description: Buffer Size
+sidebar:
+  label: Buffer Size
+  order: 3
+---
+
+### `size.buffer.<bufferName>=<width> <height>`
+
+#### Location: shaders.properties
+
+The resolution of [colortex](/reference/buffers/colortex) buffers can be configured with this directive in `shaders.properties`. Replace `<bufferName>` with the name of the buffer (e.g. `colortex5`), then replace `<width>` and `<height>` with the resolution of the buffer. If the passed dimensions are integer, that will define the resolution of the buffer in pixels. If the dimensions are floating point, it will define the resolution of the buffer relative to the screen resolution. For example, `size.buffer.colortex5=0.75 0.25` will make `colortex5` three quarters the width and one quarter the height of the Minecraft window.
+
+Any buffer whose size is changed cannot be rendered to by a [`gbuffers`](/reference/programs/gbuffers) pass, meaning it can only be rendered to through a [`begin`](/reference/programs/begin), [`prepare`](/reference/programs/prepare), [`deferred`](/reference/programs/deferred), or [`composite`](/reference/programs/composite) program. Additionally, any individual program can only render to buffers with identical sizes. This exception does not apply to image bindings or compute programs.

--- a/src/content/docs/reference/Directives/colortex_mipmaps.mdx
+++ b/src/content/docs/reference/Directives/colortex_mipmaps.mdx
@@ -1,0 +1,15 @@
+---
+title: Colortex Mipmaps
+description: Colortex Mipmaps
+sidebar:
+  label: Colortex Mipmaps
+  order: 3
+---
+
+### `const bool <bufferName>MipmapEnabled = true;`
+
+#### Location: composite, deferred, final, prepare
+
+This directive tells Iris to generate a mipmap chain for a [colortex](/reference/buffers/colortex) attachment. The mipmap chain will be generated directly before the program where the directive is included, if there are multiple programs it will be re-generated before each program containing the directive. This directive is only valid for [`begin`](/reference/programs/begin), [`prepare`](/reference/programs/prepare), [`deferred`](/reference/programs/deferred), or [`composite`](/reference/programs/composite) programs.
+
+Replace `<bufferName>` with the name of a colortex sampler (e.g. `colortex2`).

--- a/src/content/docs/reference/Directives/drawbuffers.mdx
+++ b/src/content/docs/reference/Directives/drawbuffers.mdx
@@ -1,0 +1,17 @@
+---
+title: DRAWBUFFERS
+description: DRAWBUFFERS Directive
+sidebar:
+  label: DRAWBUFFERS
+  order: 2
+---
+
+### `/* DRAWBUFFERS:XYZ */`
+
+#### Location: any fragment stage (.fsh) of any program
+
+The legacy version of the [`RENDERTARGETS`](/reference/directives/rendertargets) directive. This directive can only reference indicies 0 through 9, so `colortex10` through `colortex15` cannot be bound with this directive. Because of this, it is recommended to use [`RENDERTARGETS`](/reference/directives/rendertargets) directive instead as that can access all available buffers.
+
+To use this directive replace `XYZ` with the sequence of indices of color attachments. For example, putting `/* DRAWBUFFERS:0178 */` in `composite.fsh` would configure that program to write to `colortex0`, `colortex1`, `colortex7`, and `colortex8`. The comment can be placed anywhere in the `.fsh` file.
+
+More information on how this buffer applies to outputing values is in the [`RENDERTARGETS`](/reference/directives/rendertargets) section.

--- a/src/content/docs/reference/Directives/flags.mdx
+++ b/src/content/docs/reference/Directives/flags.mdx
@@ -3,8 +3,13 @@ title: Feature Flags
 description: Feature Flags
 sidebar:
   label: Feature Flags
-  order: 1
+  order: 4
+  badge:
+    text: Iris Only
+    variant: tip
 ---
+
+#### Location: shaders.properties
 
 Feature flags are an Iris system to query the activation state of certain features. To activate them there are two directives that can be placed in `shader.properties`: `iris.features.required` and `iris.features.optional`. `iris.features.required` will throw an error if your device or version of Iris does not support the feature. `iris.features.optional` will create a define that can be used to test the availability of such a feature. Additionally the `IS_IRIS` define can be used to test if your shader is in Iris or optifine, and always exists.
 <br/>

--- a/src/content/docs/reference/Directives/rendertargets.mdx
+++ b/src/content/docs/reference/Directives/rendertargets.mdx
@@ -1,0 +1,21 @@
+---
+title: RENDERTARGETS
+description: RENDERTARGETS Directive
+sidebar:
+  label: RENDERTARGETS
+  order: 1
+---
+
+### `/* RENDERTARGETS: X,Y,Z */`
+
+#### Location: any fragment stage (.fsh) of any program
+
+This directive is used to configure which color attachments a fragment program outputs to. Replace `X,Y,Z` with the comma separated list of indices of color attachments. For example, putting `/* RENDERTARGETS: 0,3,7,13 */` in `composite.fsh` would configure that program to write to `colortex0`, `colortex3`, `colortex7`, and `colortex13`. The comment can be placed anywhere in the `.fsh` file. If the directive (or the [`DRAWBUFFERS`](/reference/directives/drawbuffers) directive) is not found in the file, the first 8 buffers will be bound.
+
+**Note**: This directive must include the multi-line comments and should be on its own line.
+
+The directive creates a map between the color attachment index used in the glsl code and the [colortex](/reference/buffers/colortex) or [shadowcolor](/reference/buffers/shadowcolor) buffer. For example, if the line `/* RENDERTARGETS: 0,3,7,13 */` is used, `colortex0` would be at index 0 and `colortex13` at index 3. There are three methods to access this output depending on the glsl version in use:
+
+1. Legacy versions and compatibility profiles have access to `gl_FragData[<index>]`, an array that can be written to with the attachment index like a standard `vec4` array. In the above example writing to `gl_FragData[2]` would write to `colortex7`.
+2. Modern versions (130+) can use the `out vec4 outColorN;` variable, where `N` is replaced with the array index. In the above example writing to `outColor2` would write to `colortex7`.
+3. Newer modern versions (330+) can use layout qualifiers to specify the index, allowing the varible name to be changed. In the above example `layout(location = 2) out vec4 anArbitraryOutputName;` would write to `colortex7`.

--- a/src/content/docs/reference/Directives/shadow_mipmaps.mdx
+++ b/src/content/docs/reference/Directives/shadow_mipmaps.mdx
@@ -1,0 +1,38 @@
+---
+title: Shadow Mipmaps
+description: Shadow Mipmaps
+sidebar:
+  label: Shadow Mipmaps
+  order: 3
+---
+
+# Shadowtex
+
+##### `const bool generateShadowMipmap = true;`
+##### `const bool shadowtexMipmap = true;`
+##### `const bool shadowtex0Mipmap = true;`
+##### `const bool shadowtex1Mipmap = true;`
+
+#### Location: any glsl file
+
+These directives tells Iris to generate a mipmap chain for a [shadowtex](/reference/buffers/shadowtex) buffer. This directive only needs to be defined once in the shader pack, and can be defined in (mostly) any shader file. The mipmap will be generated after the [`shadow`](/reference/programs/shadow) pass but before [`shadowcomp`](/reference/programs/shadow_comp).
+
+`generateShadowMipmap` will generate mipmaps for both `shadowtex0` and `shadowtex1`, whereas `shadowtexMipmap` will generate mipmaps for only `shadowtex0`.
+
+
+# ShadowColor
+
+##### `const bool generateShadowColorMipmap = true;`
+##### `const bool shadowcolor0Mipmap = true;`
+##### `const bool shadowColor0Mipmap = true;`
+##### `const bool shadowcolor1Mipmap = true;`
+##### `const bool shadowColor1Mipmap = true;`
+
+#### Location: any glsl file
+
+These directives tells Iris to generate a mipmap chain for a [shadowcolor](/reference/buffers/shadowcolor) buffer. This directive only needs to be defined once in the shader pack, and can be defined in (mostly) any shader file. The mipmap will be generated after the [`shadow`](/reference/programs/shadow) pass but before [`shadowcomp`](/reference/programs/shadow_comp).
+
+`generateShadowColorMipmap` will generate mipmaps for both `shadowcolor0` and `shadowcolor1`.
+
+### ***WARNING:***
+this feature is currently bugged in Iris, no mipmaps for shadowcolor buffers will be generated, however mipmaps for shadowtex buffers work fine.


### PR DESCRIPTION
This is a big one! We've got everything I could think of related to buffers/textures and most of the directives for configuring them. This includes:

Buffers:
- colortex
- custom
- depthtex
- noisetex
- shadowcolor
- shadowtex
- texture formats

Directives:
- buffer clear
- buffer clear color
- buffer flip / ping-pong buffers
- buffer format
- buffer size
- colortex mipmaps
- shadowtex mipmaps
- DRAWBUFFERS
- RENDERTARGETS

I also updated the feature flags section to be marked as Iris only

closes #139 
closes #140 
closes #141 
closes #142 
closes #143 
closes #144 
closes #146 
closes #147 
closes #148 
closes #149 
closes #166 
closes #167 
closes #168 
closes #169 
closes #170 
closes #171 