### PR TITLE
feat: Buffers: add SSBO and custom images

### DIFF
--- a/src/content/docs/reference/Buffers/custom_images.mdx
+++ b/src/content/docs/reference/Buffers/custom_images.mdx
@@ -1,0 +1,65 @@
+---
+title: Custom Images
+description: Custom Images
+sidebar:
+  label: Custom Images
+  order: 3
+  badge:
+    text: Iris Only
+    variant: tip
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+##### `image.<imageName> = <samplerName> <format> <internalFormat> <pixelType> <shouldClearOnNewFrame> <isRelative> <relativeX/absoluteX> <relativeY/absoluteY> <absoluteZ>`
+
+Custom images allow to write up to 8 custom full images of data. These images are similar to [colortex](/reference/buffers/colortex) buffers, except they allow for writing to arbitrary locations and from any shader file. For more info on allowed formats and restrictions, along for their use in shaders, read the [Khronos Wiki](https://www.khronos.org/opengl/wiki/Image_Load_Store).
+
+To declare a custom image, use the following in shaders.properties:
+
+`image.<imageName> = <samplerName> <format> <internalFormat> <pixelType> <shouldClearOnNewFrame> <isRelative> <relativeX/absoluteX> <relativeY/absoluteY> <absoluteZ>`
+
+Replace:
+- `<imageName>` with the variable name of the image
+- `<samplerName>` with the variable name of the sampler
+- `<format>` with the [pixel format](/reference/buffers/texture_format) of the image (see "Pixel Formats" section)
+- `<internalFormat>` with the [texture format](/reference/buffers/texture_format) of the image (see "Texture Format" section)
+- `<pixelType>` with the [pixel type](/reference/buffers/texture_format) of the image (see "Pixel Types" section)
+- `<shouldClearOnNewFrame>` with `true` to clear the image after each frame, or `false` to retain data between frames
+- `<isRelative>` with `true` to make the image dimensions relative to the screen dimensions, or `false` to make the dimensions absolute
+- `<relativeX/absoluteX>` with the relative (floating point) or absolute (integer) size in the x dimension
+- `<relativeY/absoluteY>` with the relative (floating point) or absolute (integer) size in the y dimension
+- `<absoluteZ>` with the absolute (integer) size in the z dimension
+
+For example, to declare a `RGBA32F` custom image half the screen size that does not clear, use the following:
+
+`image.cimage1 = cSampler1 rgba rgba32f float false true 0.5 0.5`
+
+And to declare a `RGBA8` 3D custom image with dimensions of 512x512x512 that clears every frame:
+
+`image.cimage1 = cSampler1 rgba rgba8 float true false 512 512 512`
+
+This image can be accessed in 2 ways:
+
+- The image can be written and read per-pixel by declaring it as an image:
+
+```glsl
+uniform image2D cimage1;
+
+void main() {
+    vec4 previousValue = imageLoad(cimage1, ivec2(0, 0)); // Reads from first pixel in the image
+    imageStore(cimage1, ivec2(0, 0), vec4(1, 0, 0, 1)); // Writes to first pixel in the image
+}
+```
+
+- Or the image can be read with filtering as a sampler:
+
+```glsl
+uniform sampler2D cSampler1;
+varying float viewWidth;
+varying float viewHeight;
+
+void main() {
+    gl_FragColor = texture2D(cSampler1, gl_FragCoord.xy / vec2(viewWidth, viewHeight)); // Samples the current pixel of the image with smooth linear filtering.
+}
+```

--- a/src/content/docs/reference/Buffers/custom_textures.mdx
+++ b/src/content/docs/reference/Buffers/custom_textures.mdx
@@ -1,8 +1,8 @@
 ---
-title: Custom Buffers
-description: Custom Buffers
+title: Custom Textures
+description: Custom Textures
 sidebar:
-  label: Custom Buffers
+  label: Custom Textures
   order: 2
 ---
 

--- a/src/content/docs/reference/Buffers/ssbo.mdx
+++ b/src/content/docs/reference/Buffers/ssbo.mdx
@@ -1,0 +1,57 @@
+---
+title: SSBOs
+description: SSBOs
+sidebar:
+  label: SSBOs
+  order: 3
+  badge:
+    text: Iris Only
+    variant: tip
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+### `bufferObject.<index> = <byteSize>`
+### `bufferObject.<index> = <byteSize> <isRelative> <scaleX> <scaleY>`
+
+Shader Storage Buffer Objects (or SSBO's) are buffers that can store large amounts of data between shader invocations, and even between frames. Unlike images, they allow storing arbitrary data types. For more information about the limits of SSBO's in OpenGL, read the [Khronos Wiki](https://www.khronos.org/opengl/wiki/Shader_Storage_Buffer_Object).
+
+SSBO's can hold a guaranteed maximum of 128MB, and on most drivers can hold as much as the GPU physically alllows. Iris will give an error and fail to load a shader if allocating an SSBO would otherwise use up too much VRAM.
+
+To allocate an SSBO for a shaderpack, put the following in `shaders.properties`, where index can be between 0 and 8:
+
+`bufferObject.<index> = <byteSize> <isRelative> <scaleX> <scaleY>`
+
+To define the SSBO as fixed size, simply exclude the last three options and fill `<byteSize>` with the size of the SSBO.
+
+SSBOs can also be defined as screen-sized (Iris 1.6.6 and later), where their size is relative to the screen dimensions. This is useful for storing data per-pixel. Fill `<isRelative>` with true, `<scaleX>` and `<scaleY>` then define the multipliers for the number of "pixels" in the SSBO relative to each screen dimension (i.e. 1.0 would mean the same dimension as the screen), and `<byteSize>` defines the number of bytes per "pixel". The total size of the SSBO is calculated as `int(viewWidth * scaleX) * int(viewHeight * scaleY) * byteSize`.
+
+To use an SSBO in a shader, you must define it's layout. Here is an example definition of a SSBO, where bufferName can be any name:
+
+**This layout must be the same across all shaders, otherwise the data will get corrupted.**
+
+```glsl
+layout(std430, binding = index) buffer bufferName {
+    vec4 someData; // 16 bytes
+    float someExtraData; // 4 bytes
+};
+
+void main() {
+    someData = vec4(0); // Other shaders will see this
+    gl_FragColor = vec4(someExtraData); // Read from any previous shaders, or the previous frame if it was never overwritten
+}
+```
+
+You can optionally make all the variables of an SSBO local to avoid redefinitions. To do this, declare an accessor for the SSBO, as the following.
+
+```glsl
+layout(std430, binding = index) buffer bufferName {
+    vec4 someData; // 16 bytes
+    float someExtraData; // 4 bytes
+} bufferAccess;
+
+void main() {
+    bufferAccess.someData = vec4(0); // Other shaders will see this
+    gl_FragColor = vec4(bufferAccess.someExtraData); // Read from any previous shaders, or the previous frame if it was never overwritten
+}
+```

--- a/src/content/docs/reference/Buffers/texture_format.mdx
+++ b/src/content/docs/reference/Buffers/texture_format.mdx
@@ -3,7 +3,7 @@ title: Texture Format
 description: Texture Format
 sidebar:
   label: Texture Format
-  order: 3
+  order: 4
 ---
 
 import { Aside } from '@astrojs/starlight/components';


### PR DESCRIPTION
- Add page for SSBOs
- Add page for custom images
- Renamed "custom buffers" to "custom textures"

closes #187 
closes #188 