### PR TITLE
Improve quick reference page (also minor fix on the readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For uniform references please look at `alphaTestRef` for formatting. The aside f
 
 ### PR's and Commits
 
-PR's May take a while to be added, as they need to be fully verified, and someone needs to add them when there on. 
+PR's May take a while to be added, as they need to be fully verified, and someone needs to add them when they're on. 
 
 #### PR/Commit Format (Please Use it in both your commits on your branch and any pr's, makes our lives easy)
 (type): (area): description
@@ -85,3 +85,4 @@ Translations are not yet supported, but once the english version is complete we 
 - [Iris Docs](https://github.com/IrisShaders/ShaderDoc/tree/master) - Most of the early documentation
 - WhyFencePost / WhyFenceCode - The page and a lot of the data transfer
 - NinjaMike - Many uniforms including Iris exclusive uniforms
+- jbritain - Some uniforms, other miscellaneous things

--- a/README.md
+++ b/README.md
@@ -84,5 +84,5 @@ Translations are not yet supported, but once the english version is complete we 
 ## Contributors
 - [Iris Docs](https://github.com/IrisShaders/ShaderDoc/tree/master) - Most of the early documentation
 - WhyFencePost / WhyFenceCode - The page and a lot of the data transfer
-- NinjaMike - Many uniforms including Iris exclusive uniforms
+- NinjaMike - Many uniforms including Iris exclusive uniforms, constants, shaders.properties, programs
 - jbritain - Some uniforms, other miscellaneous things

--- a/src/content/docs/reference/overview.mdx
+++ b/src/content/docs/reference/overview.mdx
@@ -11,16 +11,16 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 ## Core Reference
 
-There on the left, look in the nav bar!
+There on the left, look in the nav bar! On mobile, you'll need to hit that hamburger icon on the top right!
 
 ## Quick Reference
 <LinkCard
   title="Distant Horizons"
-  description="Just a quick link to the docs on writing for DH!"
-  href=""
+  description="How to support Distant Horizons in your shader."
+  href="/reference/mod/dh/dh_overview/"
 />
 <LinkCard
   title="Feature Flags"
-  description="Good old feature flags"
+  description="Query the activation state of certain features."
   href="/reference/shadersproperties/flags"
 />


### PR DESCRIPTION
This PR improves the 'quick reference' section of the overview page, making the descriptions of the cards more clear, and also adding a link for the DH section.

Also I fixed a minor grammatical error in the readme because I'm pedantic like that.