### PR TITLE
feat/fix: Uniforms: add missing uniforms, fix several incorrect uniforms

### DIFF
--- a/src/content/docs/reference/Attributes/vaPosition.mdx
+++ b/src/content/docs/reference/Attributes/vaPosition.mdx
@@ -12,12 +12,17 @@ import { Aside } from '@astrojs/starlight/components';
 
 <Aside type="danger">This attribute only works with the "core profile" in Minecraft `1.17` and newer. It is recommended to use the "compatibility profile" with Iris for better support. </Aside>
 
-### `in vec4 vaPosition;`
+### `in vec3 vaPosition;`
 
 **Valid Programs**: all gbuffers/shadow
 
 ---
 
-The vertex position attribute, equivalent to `gl_Vertex` from the compatibility profile.
+The vertex position attribute. For terrain this is relative to the chunk and you must add [`chunkOffset`](/reference/uniforms/general/chunkoffset) as shown below:
+```glsl
+vec3 model_pos = vaPosition + chunkOffset;
+```
 
-The vertex position from `vaPosition` is in model space (which varies for different geometry). It can be converted to view space using [`modelViewMatrix`](/reference/uniforms/matrices/modelviewmatrix) (or `gl_ModelViewMatrix` in the compatibility profile).
+For all other geometry, `vaPosition` directly stores the model space position. In either case, the model space position is equivalent to `gl_Vertex.xyz` from the compatibility profile.
+
+The model space position can be converted to view space using [`modelViewMatrix`](/reference/uniforms/matrices/modelviewmatrix) (or `gl_ModelViewMatrix` in the compatibility profile).

--- a/src/content/docs/reference/Uniforms/General/alphaTestRef.mdx
+++ b/src/content/docs/reference/Uniforms/General/alphaTestRef.mdx
@@ -4,9 +4,6 @@ description: alphaTestRef
 sidebar:
   label: alphaTestRef
   order: 1
-  badge:
-    text: 1.17+
-    variant: danger
 ---
 import { Aside } from '@astrojs/starlight/components';
 
@@ -16,3 +13,5 @@ This value stores the alpha value that Iris recommends you discard pixels bellow
 ```glsl
 if (albedoOut.a < alphaTestRef) discard;
 ```
+
+<Aside type="note">This uniform is designed to work with the modern syntax for fragment shader outputs (`out`). When Using the legacy syntax (`gl_FragData`) this uniform is not necessary as the alpha test will be performed automatically.</Aside>

--- a/src/content/docs/reference/Uniforms/General/blendFunc.mdx
+++ b/src/content/docs/reference/Uniforms/General/blendFunc.mdx
@@ -4,9 +4,29 @@ description: blendFunc
 sidebar:
   label: blendFunc
   order: 1
-  badge:
-    text: Unfinished
-    variant: caution
 ---
 
 ### `uniform ivec4 blendFunc;`
+
+The alpha blending function multipliers for the current program, as described in [`blend.<program>`](/reference/shadersproperties/blend). The components of the vector store the following:
+
+- `x`: source RGB
+- `y`: destination RGB
+- `z`: source Alpha
+- `w`: destination Alpha
+
+The value stored in each component is one of the following hardcoded integer values (see [LWJGL docs](https://javadoc.lwjgl.org/constant-values.html#org.lwjgl.opengl.GL11.GL_SRC_COLOR)):
+
+| Blend Value             | Integer Value |
+|-------------------------|---------------|
+| `GL_ZERO`               | 0             |
+| `GL_ONE`                | 1             |
+| `GL_SRC_COLOR`          | 768           |
+| `GL_ONE_MINUS_SRC_COLOR`| 769           |
+| `GL_SRC_ALPHA`          | 770           |
+| `GL_ONE_MINUS_SRC_ALPHA`| 771           |
+| `GL_DST_ALPHA`          | 772           |
+| `GL_ONE_MINUS_DST_ALPHA`| 773           |
+| `GL_DST_COLOR`          | 774           |
+| `GL_ONE_MINUS_DST_COLOR`| 775           |
+| `GL_SRC_ALPHA_SATURATE` | 776           |

--- a/src/content/docs/reference/Uniforms/General/blockEntityId.mdx
+++ b/src/content/docs/reference/Uniforms/General/blockEntityId.mdx
@@ -8,4 +8,4 @@ sidebar:
 
 ### `uniform int blockEntityId;`
 
-This uniform stores the id(`block.properties`) of the current block entity (a tile entity). Value is `0` if no `block.properties` is present. Value is `65535` if `block.properties` is present and the block is either not in the file, or not en entity (this includes holding nothing).
+This uniform stores the id (`block.properties`) of the current block entity (a tile entity). Value is `0` if no `block.properties` is present. Value is `65535` if `block.properties` is present and the block is either not in the file, or not en entity (this includes holding nothing).

--- a/src/content/docs/reference/Uniforms/General/chunkOffset.mdx
+++ b/src/content/docs/reference/Uniforms/General/chunkOffset.mdx
@@ -5,11 +5,19 @@ sidebar:
   label: chunkOffset
   order: 1
   badge:
-    text: Unfinished
-    variant: caution
+    text: 1.17+
+    variant: danger
 ---
 import { Aside } from '@astrojs/starlight/components';
 
-<Aside type="danger">This uniform only works on `1.17` and newer.</Aside>
+<Aside type="danger">This uniform only works with the "core profile" in Minecraft `1.17` and newer. It is recommended to use the "compatibility profile" with Iris for better support.</Aside>
 
 ### `uniform vec3 chunkOffset;`
+
+The chunk offset in model space for the currently rendering chunk of terrain. Used in combination with [`vaPosition`](/reference/attributes/vaposition) to get the model space position as follows:
+
+```glsl
+vec3 model_pos = vaPosition + chunkOffset;
+```
+
+The value of `chunkOffset` is all 0s when not rendering terrain, or when using the compatibility profile.

--- a/src/content/docs/reference/Uniforms/General/constantMood.mdx
+++ b/src/content/docs/reference/Uniforms/General/constantMood.mdx
@@ -1,0 +1,14 @@
+---
+title: constantMood
+description: constantMood
+sidebar:
+  label: constantMood
+  order: 1
+  badge:
+    text: Iris Only
+    variant: tip
+---
+
+### `uniform float constantMood;`
+
+Equivalent to [`playerMood`](/reference/uniforms/general/playermood) except when it reaches the value `1.0` it stays at that value instead of resetting to `0.0`.

--- a/src/content/docs/reference/Uniforms/General/currentSelectedBlockId.mdx
+++ b/src/content/docs/reference/Uniforms/General/currentSelectedBlockId.mdx
@@ -1,0 +1,14 @@
+---
+title: currentSelectedBlockId
+description: currentSelectedBlockId
+sidebar:
+  label: currentSelectedBlockId
+  order: 1
+  badge:
+    text: Iris Only
+    variant: tip
+---
+
+### `uniform int currentSelectedBlockId;`
+
+This uniform stores the id (`block.properties`) of the block selected by the player (with the block outline). Value is `0` if no block is selected, if the selected block is not in `block.properties`, or if no `block.properties` is file present.

--- a/src/content/docs/reference/Uniforms/General/currentSelectedBlockPos.mdx
+++ b/src/content/docs/reference/Uniforms/General/currentSelectedBlockPos.mdx
@@ -1,0 +1,14 @@
+---
+title: currentSelectedBlockPos
+description: currentSelectedBlockPos
+sidebar:
+  label: currentSelectedBlockPos
+  order: 1
+  badge:
+    text: Iris Only
+    variant: tip
+---
+
+### `uniform vec3 currentSelectedBlockId;`
+
+This uniform stores the player space position of the center of the block selected by the player (with the block outline). If no block is selected, the values of all components will be `-256.0`.

--- a/src/content/docs/reference/Uniforms/General/darknessFactor.mdx
+++ b/src/content/docs/reference/Uniforms/General/darknessFactor.mdx
@@ -4,12 +4,8 @@ description: darknessFactor
 sidebar:
   label: darknessFactor
   order: 1
-  badge:
-    text: Unfinished
-    variant: caution
 ---
-import { Aside } from '@astrojs/starlight/components';
-
-<Aside type="danger">This uniform only works on `1.17` and newer.</Aside>
 
 ### `uniform float darknessFactor;`
+
+This uniform stores the strength of the darkness effect. The value is `0.0` when the effect is not present, `1.0` when the effect is active, and is interpolated between those values during transitions.

--- a/src/content/docs/reference/Uniforms/General/darknessLightFactor.mdx
+++ b/src/content/docs/reference/Uniforms/General/darknessLightFactor.mdx
@@ -4,12 +4,8 @@ description: darknessLightFactor
 sidebar:
   label: darknessLightFactor
   order: 1
-  badge:
-    text: Unfinished
-    variant: caution
 ---
-import { Aside } from '@astrojs/starlight/components';
-
-<Aside type="danger">This uniform only works on `1.17` and newer.</Aside>
 
 ### `uniform float darknessLightFactor;`
+
+The darkness status effect creates a pulsating dimming effect in the game lighting. This uniform stores the current strength of the dimming effect. The value is `0.0` is the minimum dimming, `1.0` when the effect is the maximum dimming, and is interpolated between those values during transitions.

--- a/src/content/docs/reference/Uniforms/General/entityId.mdx
+++ b/src/content/docs/reference/Uniforms/General/entityId.mdx
@@ -8,4 +8,4 @@ sidebar:
 
 ### `uniform int entityId;`
 
-This uniform stores the id(`entity.properties`) of the current entity. Value is `0` if no `entity.properties` is present. Value `65535` if `entity.properties` is present and the entity is not in the file.
+This uniform stores the id (`entity.properties`) of the current entity. Value is `0` if no `entity.properties` is present. Value `65535` if `entity.properties` is present and the entity is not in the file.

--- a/src/content/docs/reference/Uniforms/General/eyeBrightness.mdx
+++ b/src/content/docs/reference/Uniforms/General/eyeBrightness.mdx
@@ -4,9 +4,8 @@ description: eyeBrightness
 sidebar:
   label: eyeBrightness
   order: 1
-  badge:
-    text: Unfinished
-    variant: caution
 ---
 
 ### `uniform ivec2 eyeBrightness;`
+
+The lightmap value at the player's location. The `x` component stores the block light and the `y` component stores the sky light. The value is stored in the range [0-240].

--- a/src/content/docs/reference/Uniforms/General/eyeBrightnessSmooth.mdx
+++ b/src/content/docs/reference/Uniforms/General/eyeBrightnessSmooth.mdx
@@ -4,9 +4,8 @@ description: eyeBrightnessSmooth
 sidebar:
   label: eyeBrightnessSmooth
   order: 1
-  badge:
-    text: Unfinished
-    variant: caution
 ---
 
 ### `uniform ivec2 eyeBrightnessSmooth;`
+
+This uniform stores the value of [`eyeBrightness`](/reference/uniforms/general/eyebrightness), smoothed over time. The speed of the smoothing can be controlled with [`eyeBrightnessHalflife`](/reference/constants/eyebrightnesshalflife).

--- a/src/content/docs/reference/Uniforms/General/fogColor.mdx
+++ b/src/content/docs/reference/Uniforms/General/fogColor.mdx
@@ -8,4 +8,4 @@ sidebar:
 
 ### `uniform vec3 fogColor;`
 
-This vector 3 stores the color that the game has calculated that the fog should be for a pixel/fragment. This value is based on the [skyColor](/reference/uniforms/general/skycolor) in the area.
+The horizon fog color used by the vanilla game for sky rendering and fog. It can be dependent on biome, time of day, and viewing angle.

--- a/src/content/docs/reference/Uniforms/General/fogDensity.mdx
+++ b/src/content/docs/reference/Uniforms/General/fogDensity.mdx
@@ -8,4 +8,4 @@ sidebar:
 
 ### `uniform float fogDensity;`
 
-This uniform stores the value of the suggested density of fog based on depth of the current fragment. This value is `0` when there shall be no fog, and is `1` when there should be full fog and no other visibility. This value interpolates between the two based on depth.
+This uniform stores the relative fog density used for vanilla fog, based on the current biome, weather, water/lava/packed snow, etc. The value ranges from `0.0` (lowest density) to `1.0` (highest density).

--- a/src/content/docs/reference/Uniforms/General/fogEnd.mdx
+++ b/src/content/docs/reference/Uniforms/General/fogEnd.mdx
@@ -1,0 +1,11 @@
+---
+title: fogEnd
+description: fogEnd
+sidebar:
+  label: fogEnd
+  order: 1
+---
+
+### `uniform float fogEnd;`
+
+This uniform stores the ending distance in blocks used for vanilla fog, based on the current biome, weather, water/lava/packed snow, etc.

--- a/src/content/docs/reference/Uniforms/General/fogMode.mdx
+++ b/src/content/docs/reference/Uniforms/General/fogMode.mdx
@@ -4,9 +4,14 @@ description: fogMode
 sidebar:
   label: fogMode
   order: 1
-  badge:
-    text: Unfinished
-    variant: caution
 ---
 
 ### `uniform int fogMode;`
+
+This uniform stores the fog type used for vanilla fog, based on the current biome, weather, water/lava/packed snow, etc. This is the function used to determine the strength of fog based on distance.
+
+The value stored in each component is one of the following hardcoded integer values (see [LWJGL docs](https://javadoc.lwjgl.org/constant-values.html#org.lwjgl.opengl.GL11.GL_EXP)):
+
+- `GL_EXP`: 2048
+- `GL_EXP2` : 2049
+- `GL_LINEAR`: 9729

--- a/src/content/docs/reference/Uniforms/General/fogShape.mdx
+++ b/src/content/docs/reference/Uniforms/General/fogShape.mdx
@@ -1,0 +1,14 @@
+---
+title: fogShape
+description: fogShape
+sidebar:
+  label: fogShape
+  order: 1
+---
+
+### `uniform int fogShape;`
+
+This uniform encodes the fog shape used for vanilla fog, based on the current biome, weather, water/lava/packed snow, caves, etc. The following values are possible:
+
+- `0`: sphere
+- `1`: cylinder

--- a/src/content/docs/reference/Uniforms/General/fogStart.mdx
+++ b/src/content/docs/reference/Uniforms/General/fogStart.mdx
@@ -1,0 +1,11 @@
+---
+title: fogStart
+description: fogStart
+sidebar:
+  label: fogStart
+  order: 1
+---
+
+### `uniform float fogStart;`
+
+This uniform stores the starting distance in blocks used for vanilla fog, based on the current biome, weather, water/lava/packed snow, etc.

--- a/src/content/docs/reference/Uniforms/General/screenBrightness.mdx
+++ b/src/content/docs/reference/Uniforms/General/screenBrightness.mdx
@@ -4,9 +4,6 @@ description: screenBrightness
 sidebar:
   label: screenBrightness
   order: 1
-  badge:
-    text: Outdated
-    variant: caution
 ---
 
 ### `uniform float screenBrightness;`

--- a/src/content/docs/reference/Uniforms/General/skyColor.mdx
+++ b/src/content/docs/reference/Uniforms/General/skyColor.mdx
@@ -4,11 +4,8 @@ description: skyColor
 sidebar:
   label: skyColor
   order: 1
-  badge:
-    text: Unfinished
-    variant: caution
 ---
 
 ### `uniform vec3 skyColor;`
 
-This vector 3 stores the color that the game has calculated that the vanilla sky should be for a pixel/fragment. This color is provided as an RGB color.
+The upper sky color used by the vanilla game for sky rendering. It can be dependent on biome, time of day, but not viewing angle.


### PR DESCRIPTION
Added the following uniforms:
- blendFunc
- chunkOffset
- constantMood
- currentSelectedBlockId
- currentSelectedBlockPos
- darknessFactor
- darknessLightFactor
- eyeBrightness
- eyeBrightnessSmooth
- fodEnd
- fogMode
- fogShape
- fogStart

Fixes for the following uniforms/attributes
- vaPosition
- alphaTestRef
- blockEntityId
- entityId
- fogColor
- fogDensity
- screenBrightness
- skyColor

closes #28 
closes #31 
closes #41 
closes #42 
closes #46 
closes #47 
closes #53 
closes #222 
closes #277 
closes #278 
closes #279 
closes #280 
closes #281 