### PR TITLE
feat: Macros: added preprocessor macros

### DIFF
--- a/src/content/docs/reference/Macros/Driver_Vendor.mdx
+++ b/src/content/docs/reference/Macros/Driver_Vendor.mdx
@@ -1,0 +1,17 @@
+---
+title: Driver Vendor
+description: Driver Vendor
+sidebar:
+  label: Driver Vendor
+  order: 1
+---
+
+Based on the current GPU driver vendor, one of the following macros will be defined:
+
+- `MC_GL_VENDOR_AMD`
+- `MC_GL_VENDOR_ATI`
+- `MC_GL_VENDOR_INTEL`
+- `MC_GL_VENDOR_MESA`
+- `MC_GL_VENDOR_NVIDIA`
+- `MC_GL_VENDOR_XORG`
+- `MC_GL_VENDOR_OTHER`

--- a/src/content/docs/reference/Macros/GPU_Hardware.mdx
+++ b/src/content/docs/reference/Macros/GPU_Hardware.mdx
@@ -1,0 +1,17 @@
+---
+title: GPU Hardware
+description: GPU Hardware
+sidebar:
+  label: GPU Hardware
+  order: 1
+---
+
+Based on the current GPU hardware model, one of the following macros will be defined:
+
+- `MC_GL_RENDERER_RADEON`
+- `MC_GL_RENDERER_GEFORCE`
+- `MC_GL_RENDERER_QUADRO`
+- `MC_GL_RENDERER_INTEL`
+- `MC_GL_RENDERER_GALLIUM`
+- `MC_GL_RENDERER_MESA`
+- `MC_GL_RENDERER_OTHER`

--- a/src/content/docs/reference/Macros/IRIS_HAS_CONNECTED_TEXTURES.mdx
+++ b/src/content/docs/reference/Macros/IRIS_HAS_CONNECTED_TEXTURES.mdx
@@ -1,0 +1,14 @@
+---
+title: IRIS_HAS_CONNECTED_TEXTURES
+description: IRIS_HAS_CONNECTED_TEXTURES
+sidebar:
+  label: IRIS_HAS_CONNECTED_TEXTURES
+  order: 1
+  badge:
+    text: Iris Only
+    variant: tip
+---
+
+### `IRIS_HAS_CONNECTED_TEXTURES`
+
+This macro is defined if a recognized mod supporting connected textures (such as Continuity) is currently loaded.

--- a/src/content/docs/reference/Macros/IRIS_TAG_SUPPORT.mdx
+++ b/src/content/docs/reference/Macros/IRIS_TAG_SUPPORT.mdx
@@ -1,0 +1,14 @@
+---
+title: IRIS_TAG_SUPPORT
+description: IRIS_TAG_SUPPORT
+sidebar:
+  label: IRIS_TAG_SUPPORT
+  order: 1
+  badge:
+    text: Iris Only
+    variant: tip
+---
+
+### `IRIS_TAG_SUPPORT`
+
+This macro is defined if the version of Iris supports tags for defining block IDs in block.properties.

--- a/src/content/docs/reference/Macros/IS_IRIS.mdx
+++ b/src/content/docs/reference/Macros/IS_IRIS.mdx
@@ -1,0 +1,14 @@
+---
+title: IS_IRIS
+description: IS_IRIS
+sidebar:
+  label: IS_IRIS
+  order: 1
+  badge:
+    text: Iris Only
+    variant: tip
+---
+
+### `IS_IRIS`
+
+This macro is defined if the shader is being loaded by Iris.

--- a/src/content/docs/reference/Macros/MC_GLSL_VERSION.mdx
+++ b/src/content/docs/reference/Macros/MC_GLSL_VERSION.mdx
@@ -1,0 +1,11 @@
+---
+title: MC_GLSL_VERSION
+description: MC_GLSL_VERSION
+sidebar:
+  label: MC_GLSL_VERSION
+  order: 1
+---
+
+### `MC_GLSL_VERSION`
+
+The maximum GLSL version supported by the system. For example: 120, 330, 460, etc.

--- a/src/content/docs/reference/Macros/MC_GL_VERSION.mdx
+++ b/src/content/docs/reference/Macros/MC_GL_VERSION.mdx
@@ -1,0 +1,16 @@
+---
+title: MC_GL_VERSION
+description: MC_GL_VERSION
+sidebar:
+  label: MC_GL_VERSION
+  order: 1
+---
+
+### `MC_GL_VERSION`
+
+The maximum OpenGL version supported by the system, encoded in an integer format without the decimal point. This may be lower than the [maximum GLSL version](/reference/macros/mc_glsl_version) is it relates to the OpenGL version used by Minecraft.
+
+For example:
+- OpenGL 2.1 -> 210
+- OpenGL 3.3 -> 330
+- OpenGL 4.6 -> 460

--- a/src/content/docs/reference/Macros/MC_HAND_DEPTH.mdx
+++ b/src/content/docs/reference/Macros/MC_HAND_DEPTH.mdx
@@ -10,7 +10,7 @@ sidebar:
 
 The clip space depth multiplier applied to geometry in [`gbuffers_hand`](/reference/programs/gbuffers) and [`gbuffers_hand_water`](/reference/programs/gbuffers).
 
-The multiplier is applied in clip space automatically at the end of the program. When working backwards from the depth buffer, the multiplier should be applied in NDC space rather than screen space to produce the correct result, for example:
+The multiplier is applied in clip space automatically through the [projection matrix](/reference/uniforms/matrices/projectionMatrix]. When working backwards from the depth buffer, the multiplier should be applied in NDC space rather than screen space to produce the correct result, for example:
 
 ```glsl
 float screenDepth = texture(depthtex0, texcoord).r;

--- a/src/content/docs/reference/Macros/MC_HAND_DEPTH.mdx
+++ b/src/content/docs/reference/Macros/MC_HAND_DEPTH.mdx
@@ -1,0 +1,18 @@
+---
+title: MC_HAND_DEPTH
+description: MC_HAND_DEPTH
+sidebar:
+  label: MC_HAND_DEPTH
+  order: 1
+---
+
+### `MC_HAND_DEPTH`
+
+The clip space depth multiplier applied to geometry in [`gbuffers_hand`](/reference/programs/gbuffers) and [`gbuffers_hand_water`](/reference/programs/gbuffers).
+
+The multiplier is applied in clip space automatically at the end of the program. When working backwards from the depth buffer, the multiplier should be applied in NDC space rather than screen space to produce the correct result, for example:
+
+```glsl
+float screenDepth = texture(depthtex0, texcoord).r;
+float ndcDepth = (screenDepth * 2.0 - 1.0) / MC_HAND_DEPTH;
+```

--- a/src/content/docs/reference/Macros/MC_TEXTURE_FORMAT_LAB_PBR.mdx
+++ b/src/content/docs/reference/Macros/MC_TEXTURE_FORMAT_LAB_PBR.mdx
@@ -1,0 +1,14 @@
+---
+title: MC_TEXTURE_FORMAT_LAB_PBR
+description: MC_TEXTURE_FORMAT_LAB_PBR
+sidebar:
+  label: MC_TEXTURE_FORMAT_LAB_PBR
+  order: 1
+---
+
+Based on the current Resource Pack's texture format (defined in texture.properties), one or more of the following macros may be defined:
+
+- `MC_TEXTURE_FORMAT_LAB_PBR`
+- `MC_TEXTURE_FORMAT_LAB_PBR_1_3`
+
+`MC_TEXTURE_FORMAT_LAB_PBR` will be defined if any version of the [labPBR standard](https://shaderlabs.org/wiki/LabPBR_Material_Standard) is declared by the Resource Packs. `MC_TEXTURE_FORMAT_LAB_PBR_1_3` will only be defined if labPBR 1.3 is declared.

--- a/src/content/docs/reference/Macros/MC_VERSION.mdx
+++ b/src/content/docs/reference/Macros/MC_VERSION.mdx
@@ -12,5 +12,5 @@ The current Minecraft version, encoded in a 122 format (1 major, 2 minor, 2 rele
 
 For example:
 - 1.6.8 -> 10608
-- 1.7.10 -> 100710
-- 1.21.0 -> 102100
+- 1.7.10 -> 10710
+- 1.21.0 -> 12100

--- a/src/content/docs/reference/Macros/MC_VERSION.mdx
+++ b/src/content/docs/reference/Macros/MC_VERSION.mdx
@@ -1,0 +1,16 @@
+---
+title: MC_VERSION
+description: MC_VERSION
+sidebar:
+  label: MC_VERSION
+  order: 1
+---
+
+### `MC_VERSION`
+
+The current Minecraft version, encoded in a 122 format (1 major, 2 minor, 2 release).
+
+For example:
+- 1.6.8 -> 10608
+- 1.7.10 -> 100710
+- 1.21.0 -> 102100

--- a/src/content/docs/reference/Macros/Operating_System.mdx
+++ b/src/content/docs/reference/Macros/Operating_System.mdx
@@ -1,0 +1,14 @@
+---
+title: Operating System
+description: Operating System
+sidebar:
+  label: Operating System
+  order: 1
+---
+
+Based on the current operating system, one of the following macros will be defined:
+
+- `MC_OS_WINDOWS`
+- `MC_OS_MAC`
+- `MC_OS_LINUX`
+- `MC_OS_OTHER`

--- a/src/content/docs/reference/Macros/Render_Stages.mdx
+++ b/src/content/docs/reference/Macros/Render_Stages.mdx
@@ -1,0 +1,36 @@
+---
+title: Render Stages
+description: Render Stages
+sidebar:
+  label: Render Stages
+  order: 1
+---
+
+The uniform [`renderStage`](/reference/uniforms/general/renderstage) stores the "render stage" of the current geometry. This can be used to identify what type of geometry is being rendered in more detail than the [gbuffer program](/reference/programs/gbuffers) it's running in. The following render stages are defined by Iris as preprocessor macros:
+
+| define                                | Description                                                                                                                               |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| MC_RENDER_STAGE_NONE                  | Undefined (should not occur normally)                                                                                                     |
+| MC_RENDER_STAGE_SKY                   | The upper portion of the sky not including stars or textures like the sun/moon                                                            |
+| MC_RENDER_STAGE_SUNSET                | The lower portion of the sky used to generate the sunset effect, does not include textures like the sun/moon                              |
+| MC_RENDER_STAGE_CUSTOM_SKY            | Custom sky texture from resource pack, such as from Optifine or FabricSkyBoxes                                                            |
+| MC_RENDER_STAGE_SUN                   | Sun texture in the sky                                                                                                                    |
+| MC_RENDER_STAGE_MOON                  | Moon texture in the sky                                                                                                                   |
+| MC_RENDER_STAGE_STARS                 | Vanilla star geometry in the sky                                                                                                          |
+| MC_RENDER_STAGE_VOID                  | Void sky, which renders below the player when they are below bedrock                                                                      |
+| MC_RENDER_STAGE_TERRAIN_SOLID         | Solid terrain geometry (terrain with no cuttouts or transparent)                                                                          |
+| MC_RENDER_STAGE_TERRAIN_CUTOUT_MIPPED | Intended for cutout geometry with mipmaps, instead these are flagged as `MC_RENDER_STAGE_TERRAIN_SOLID` ***Currently unused by Iris***    |
+| MC_RENDER_STAGE_TERRAIN_CUTOUT        | Intended for cutout geometry without mipmaps, instead these are flagged as `MC_RENDER_STAGE_TERRAIN_SOLID` ***Currently unused by Iris*** |
+| MC_RENDER_STAGE_ENTITIES              | Entity geometry including nametag text                                                                                                    |
+| MC_RENDER_STAGE_BLOCK_ENTITIES        | Block entity geometry                                                                                                                     |
+| MC_RENDER_STAGE_DESTROY               | Intended to be used for the block cracks texture, ***Currently unused by Iris***                                                          |
+| MC_RENDER_STAGE_OUTLINE               | Player block selection outline, does not include any other lines (such as fishing lines and leads)                                        |
+| MC_RENDER_STAGE_DEBUG                 | Intended to be used for debug view lines, ***Currently unused by Iris***                                                                  |
+| MC_RENDER_STAGE_HAND_SOLID            | Solid or cutout geometry for held items/blocks                                                                                            |
+| MC_RENDER_STAGE_TERRAIN_TRANSLUCENT   | Transparent terrain (such as water and stained glass)                                                                                     |
+| MC_RENDER_STAGE_TRIPWIRE              | Indented to be used for the tripwire string texture, ***Currently unused by Iris***                                                       |
+| MC_RENDER_STAGE_PARTICLES             | All particle geometry                                                                                                                     |
+| MC_RENDER_STAGE_CLOUDS                | Vanilla cloud geometry                                                                                                                    |
+| MC_RENDER_STAGE_RAIN_SNOW             | Rain and snow geometry (not including particle effects)                                                                                   |
+| MC_RENDER_STAGE_WORLD_BORDER          | World border geometry                                                                                                                     |
+| MC_RENDER_STAGE_HAND_TRANSLUCENT      | Transparent geometry for held items/blocks                                                                                                |

--- a/src/content/docs/reference/Macros/Supported_Extensions.mdx
+++ b/src/content/docs/reference/Macros/Supported_Extensions.mdx
@@ -1,0 +1,11 @@
+---
+title: Supported OpenGL Extensions
+description: Supported Extensions
+sidebar:
+  label: Supported Extensions
+  order: 1
+---
+
+Iris provides macros for each [OpenGL extension](https://www.khronos.org/opengl/wiki/OpenGL_Extension) supported by the current system.
+
+The macros are defined as `MC_` followed by the extension name. For example, `MC_GL_ARB_shader_texture_lod` is only defined if the `GL_ARB_shader_texture_lod` extension is supported.

--- a/src/content/docs/reference/Uniforms/General/renderStage.mdx
+++ b/src/content/docs/reference/Uniforms/General/renderStage.mdx
@@ -11,33 +11,4 @@ sidebar:
 
 ### `uniform int renderStage;`
 
-This uniform stores the "render stage" of the current geometry. This can be used to identify what type of geometry is being rendered in more detail than the gbuffer program it's running in. The uniform value is intended to be compared to one of the following preprocessor macros which are defined by Iris:
-
-| define                                | Description                                                                                                                                |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| MC_RENDER_STAGE_NONE                  | Unfinished                                                                                                                                |
-| MC_RENDER_STAGE_SKY                   | The upper portion of the sky not including stars or textures like the sun/moon                                                             |
-| MC_RENDER_STAGE_SUNSET                | The lower portion of the sky used to generate the sunset effect, does not include textures like the sun/moon                               |
-| MC_RENDER_STAGE_CUSTOM_SKY            | Custom sky texture from resource pack, such as from Optifine or FabricSkyBoxes                                                             |
-| MC_RENDER_STAGE_SUN                   | Sun texture in the sky                                                                                                                     |
-| MC_RENDER_STAGE_MOON                  | Moon texture in the sky                                                                                                                    |
-| MC_RENDER_STAGE_STARS                 | Vanilla star geometry in the sky                                                                                                           |
-| MC_RENDER_STAGE_VOID                  | Void sky, which renders below the player when they are below bedrock                                                                       |
-| MC_RENDER_STAGE_TERRAIN_SOLID         | Solid terrain geometry (terrain with no cuttouts or transparent)                                                                           |
-| MC_RENDER_STAGE_TERRAIN_CUTOUT_MIPPED | Intended for cuttout geometry with mipmaps, instead these are flagged as `MC_RENDER_STAGE_TERRAIN_SOLID` ***Currently unused by Iris***    |
-| MC_RENDER_STAGE_TERRAIN_CUTOUT        | Intended for cuttout geometry without mipmaps, instead these are flagged as `MC_RENDER_STAGE_TERRAIN_SOLID` ***Currently unused by Iris*** |
-| MC_RENDER_STAGE_ENTITIES              | Entity geometry including nametag text                                                                                                     |
-| MC_RENDER_STAGE_BLOCK_ENTITIES        | Block entity geometry                                                                                                                      |
-| MC_RENDER_STAGE_DESTROY               | Intended to be used for the block destorying texture, *Currently unused by Iris*                                                           |
-| MC_RENDER_STAGE_OUTLINE               | Player block selection outline, does not include any other lines (such as fishing lines and leads)                                         |
-| MC_RENDER_STAGE_DEBUG                 | ***Unknown, needs more information***                                                                                                      |
-| MC_RENDER_STAGE_HAND_SOLID            | Solid or cutout geometry for held items/blocks                                                                                             |
-| MC_RENDER_STAGE_TERRAIN_TRANSLUCENT   | Transparent terrain (such as water and stained glass)                                                                                      |
-| MC_RENDER_STAGE_TRIPWIRE              | Indented to be used for the tripwire string texture, ***Currently unused by Iris***                                                        |
-| MC_RENDER_STAGE_PARTICLES             | All particle geometry                                                                                                                      |
-| MC_RENDER_STAGE_CLOUDS                | Vanilla cloud geometry                                                                                                                     |
-| MC_RENDER_STAGE_RAIN_SNOW             | Rain and snow geometry                                                                                                                     |
-| MC_RENDER_STAGE_WORLD_BORDER          | World border geometry                                                                                                                      |
-| MC_RENDER_STAGE_HAND_TRANSLUCENT      | Transparent geometry for held items/blocks                                                                                                 |
-
-***This page is imcomplete and is missing information on a few of the render stage defines***
+This uniform stores the "render stage" of the current geometry. This can be used to identify what type of geometry is being rendered in more detail than the [gbuffer program](/reference/programs/gbuffers) it's running in. The uniform value is intended to be compared to one of the [render stage preprocessor macros](/reference/macros/render_stages) which are defined by Iris.


### PR DESCRIPTION
Add all macros which are supported by Iris. Excluded macros which are defined by Iris but are not meaningful, such as options in the shader options screen in Optifine which doesn't exist in Iris (e.g. MC_NORMAL_MAP which is always defined)

closes #256 
closes #257 
closes #258 
closes #259 
closes #260 
closes #261 
closes #262 
closes #267 
closes #270 
closes #271 
closes #272 
closes #273 
closes #284 