### PR TITLE
Update buffer_clear_color.mdx

### DIFF
--- a/src/content/docs/reference/Constants/buffer_clear_color.mdx
+++ b/src/content/docs/reference/Constants/buffer_clear_color.mdx
@@ -6,7 +6,8 @@ sidebar:
   order: 3
 ---
 
-### `const bool <bufferName>ClearColor = vec4(<value>);`
+### `const vec4 <bufferName>ClearColor = vec4(<values>);`
+
 
 #### Location: any glsl shader file
 
@@ -17,5 +18,7 @@ Replace `<bufferName>` with the name of a sampler (e.g. `colortex2` or `shadowco
 By default, all [colortex](/reference/buffers/colortex) buffers are cleared to 0s (black), except `colortex0`, which is cleared to the current fog color, and `colortex1`, which is cleared to white. All [shadowcolor](/reference/buffers/shadowcolor) buffers are cleared with white by default. This directive allows changing this clear color for each attachment individually.
 
 Currently the only option for setting clear color is with a vec4 value. If the buffer stores less than four components, the leftmost components will be used and the rest discarded. For integer buffers, the bits of the float value will be intepreted as a 32-bit integer (not converted, but directly intepreted bitwise) and used as the clear color. For 16 and 8 bit buffers, any value outside the range will be clamped to the maximum or minimum value depending if it's beyond the positive or negative bound.
+
+All four components of the vec4() must be specified, as in 'const vec4 colortex1ClearColor = vec4(0.,0.,0.,0.);'.
 
 This directive only needs to be defined once in the shader pack, and can be defined in (mostly) any shader file.


### PR DESCRIPTION
fixed typo of bool to vec4, and specified all vec4 components need to be specified