### PR TITLE
feat: several 1.8 beta additions

### DIFF
--- a/src/content/docs/reference/Buffers/ssbo.mdx
+++ b/src/content/docs/reference/Buffers/ssbo.mdx
@@ -11,21 +11,33 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 
-### `bufferObject.<index> = <byteSize>`
+### `bufferObject.<index> = <totalByteSize>`
 ### `bufferObject.<index> = <byteSize> <isRelative> <scaleX> <scaleY>`
 
 Shader Storage Buffer Objects (or SSBO's) are buffers that can store large amounts of data between shader invocations, and even between frames. Unlike images, they allow storing arbitrary data types. For more information about the limits of SSBO's in OpenGL, read the [Khronos Wiki](https://www.khronos.org/opengl/wiki/Shader_Storage_Buffer_Object). Using SSBOs with Iris requires the [`SSBO`](/reference/shadersproperties/flags) feature flag.
 
 SSBO's can hold a guaranteed maximum of 128MB, and on most drivers can hold as much as the GPU physically alllows. Iris will give an error and fail to load a shader if allocating an SSBO would otherwise use up too much VRAM.
 
-To allocate an SSBO for a shaderpack, put the following in `shaders.properties`, where index can be between 0 and 8:
+### Fixed Size SSBOs
+To define the SSBO with a fixed size, put the following in [`shaders.properties`](/reference/shadersproperties/overview) and replace `<totalByteSize>` with the total size of the SSBO in bytes and replace `<index>` with a unique value from 0 to 8.
 
-`bufferObject.<index> = <byteSize> <isRelative> <scaleX> <scaleY>`
+```
+bufferObject.<index> = <byteSize>
+```
 
-To define the SSBO as fixed size, simply exclude the last three options and fill `<byteSize>` with the size of the SSBO.
+### Screen-Sized SSBOs
+SSBOs can also be defined as screen-sized (Iris 1.6.6 and later), where their size is relative to the screen dimensions. This is useful for storing data per-pixel. To use this, put the following in [`shaders.properties`](/reference/shadersproperties/overview).
 
-SSBOs can also be defined as screen-sized (Iris 1.6.6 and later), where their size is relative to the screen dimensions. This is useful for storing data per-pixel. Fill `<isRelative>` with true, `<scaleX>` and `<scaleY>` then define the multipliers for the number of "pixels" in the SSBO relative to each screen dimension (i.e. 1.0 would mean the same dimension as the screen), and `<byteSize>` defines the number of bytes per "pixel". The total size of the SSBO is calculated as `int(viewWidth * scaleX) * int(viewHeight * scaleY) * byteSize`.
+```
+bufferObject.<index> = <byteSize> <isRelative> <scaleX> <scaleY>
+```
 
+Fill `<isRelative>` with true, then `<scaleX>` and `<scaleY>` define the multipliers for the number of "pixels" in the SSBO relative to each screen dimension (i.e. 1.0 would mean the same dimension as the screen), and `<byteSize>` defines the number of bytes per "pixel". The total size of the SSBO is calculated as `int(viewWidth * scaleX) * int(viewHeight * scaleY) * byteSize`.
+
+Like with fixed sized SSBOs, replace `<index>` with a unique value from 0 to 8.
+
+
+## Using SSBOs in your shader
 To use an SSBO in a shader, you must define it's layout. Here is an example definition of a SSBO, where bufferName can be any name:
 
 **This layout must be the same across all shaders, otherwise the data will get corrupted.**
@@ -55,3 +67,8 @@ void main() {
     gl_FragColor = vec4(bufferAccess.someExtraData); // Read from any previous shaders, or the previous frame if it was never overwritten
 }
 ```
+
+
+## Initialization Data File (Iris 1.8+)
+### `bufferObject.<index> = <byteSize> <filePath>`
+Iris 1.8 adds support for initializing an SSBO with data from a binary file. Simply append the file path to the end of the SSBO declaration in [`shaders.properties`](/reference/shadersproperties/overview). The value is be initialized at on shader load/reload. This works with only fixed sized SSBOs, and if the size of the file is bigger than the SSBO Iris will throw an error. If the file is smaller than the SSBO, the remaining data in the SSBO will be uninitialized (and is likely to be garbage data).

--- a/src/content/docs/reference/Constants/shadowFarPlane.mdx
+++ b/src/content/docs/reference/Constants/shadowFarPlane.mdx
@@ -1,0 +1,16 @@
+---
+title: shadowFarPlane
+description: The far plane distance for the shadow map.
+sidebar:
+  label: shadowFarPlane
+  order: 3
+  badge:
+    text: Iris Only
+    variant: tip
+---
+
+### `const float shadowFarPlane = 256.0;`
+
+#### Location: composite, deferred, final, prepare
+
+This constant defines the far plane distance for the shadow map, in blocks away from the shadow camera. The default value is `256.0`.

--- a/src/content/docs/reference/Constants/shadowNearPlane.mdx
+++ b/src/content/docs/reference/Constants/shadowNearPlane.mdx
@@ -1,0 +1,16 @@
+---
+title: shadowNearPlane
+description: The near plane distance for the shadow map.
+sidebar:
+  label: shadowNearPlane
+  order: 3
+  badge:
+    text: Iris Only
+    variant: tip
+---
+
+### `const float shadowNearPlane = 0.05;`
+
+#### Location: composite, deferred, final, prepare
+
+This constant defines the near plane distance for the shadow map, in blocks away from the shadow camera. The default value is `0.05`.

--- a/src/content/docs/reference/Macros/IRIS_VERSION.mdx
+++ b/src/content/docs/reference/Macros/IRIS_VERSION.mdx
@@ -11,9 +11,9 @@ sidebar:
 
 ### `IRIS_VERSION`
 
-The current Iris version, encoded in a 122 format (1 major, 2 minor, 2 release).
+The current Iris version, encoded in a 122 format (1 major, 2 minor, 2 release). This macro was added in Iris 1.8, and as such no earlier versions will be defined.
 
 For example:
-- 1.5.0 -> 10500
+- 1.8.0 -> 10800
 - 1.6.17 -> 10617
 - 1.7.3 -> 10703

--- a/src/content/docs/reference/Programs/shadow.mdx
+++ b/src/content/docs/reference/Programs/shadow.mdx
@@ -9,10 +9,22 @@ sidebar:
 **Required stages**: vertex (.vsh), fragment (.fsh)  
 **Optional stages**: geometry (.gsh), tessellation (.tcs, .tes)  
 **Output Buffers**: [shadowcolor](/reference/buffers/shadowcolor), [shadowtex](/reference/buffers/shadowtex)  
-**Valid suffixes**: N/A
+**Valid suffixes**: *N/A*
 
 -------------------------------------------------
 
 Renders world geometry into the shadow buffers, intended for use in shadow mapping.
 
 This program is similar to the [gbuffers](/reference/programs/gbuffers), except it renders terrain from the perspective of the sun or moon. Additionally there is only one shader file for this pass (for the vertex and fragment stages), so all geometry is rendered in `shadow.vsh` and `shadow.fsh`. The type of geometry rendered can be determined with [`renderStage`](/reference/uniforms/general/renderstage) instead. By default, this program renders in an orthographic perspective, this can be changed with [`shadowMapFov`](/reference/constants/shadowmapfov).
+
+
+## Additional Shadow Programs (Iris 1.8+)
+Iris 1.8 adds 5 additional shadow programs. These programs allow rendering of specific geometry with different shader code, similar to [gbuffers](/reference/programs/gbuffers). If any of these programs are not present, the geometry will be rendered in the base `shadow` program, and if that program is not present a default shader will be used.
+
+| Shadow Program    | Geometry that it renders |
+| ----------------- | ------------------------ |
+| `shadow_solid`    | solid terrain            |
+| `shadow_cutout`   | cutout terrain           |
+| `shadow_water`    | translucent terrain      |
+| `shadow_entities` | entities and beacon beam |
+| `shadow_block`    | block entities           |

--- a/src/content/docs/reference/Shaders.Properties/sky.mdx
+++ b/src/content/docs/reference/Shaders.Properties/sky.mdx
@@ -1,0 +1,16 @@
+---
+title: sky
+description: Enables or disables rendering of vanilla sky in gbuffers_skybasic.
+sidebar:
+  label: stars
+  order: 4
+  badge:
+    text: Iris 1.8 Beta
+    variant: caution
+---
+
+### `sun=<true|false>`
+
+#### Location: shaders.properties
+
+Enables or disables rendering of the vanilla sky in gbuffers_skybasic. This includes the sky disc, horizon, and void, however it does not include [`stars`](/reference/shadersproperties/stars)

--- a/src/content/docs/reference/Shaders.Properties/stars.mdx
+++ b/src/content/docs/reference/Shaders.Properties/stars.mdx
@@ -1,0 +1,16 @@
+---
+title: stars
+description: Enables or disables rendering of stars in the sky in gbuffers_skybasic.
+sidebar:
+  label: stars
+  order: 4
+  badge:
+    text: Iris 1.8 Beta
+    variant: caution
+---
+
+### `sun=<true|false>`
+
+#### Location: shaders.properties
+
+Enables or disables rendering of the vanilla star geometry in gbuffers_skybasic.

--- a/src/content/docs/reference/Uniforms/General/currentRenderedItemId.mdx
+++ b/src/content/docs/reference/Uniforms/General/currentRenderedItemId.mdx
@@ -13,7 +13,7 @@ sidebar:
 
 Iris allows detecting items and armor during rendering on *anything*.
 
-Using `uniform int currentRenderedItemId;`, you can detect items and armor rendered in the level at the point of render (based on [`item.properties`](/reference/miscellaneous/item_properties)). This is similar to [`heldItemId`](/reference/uniforms/general/helditemid) and [`heldItemId2`](/reference/uniforms/general/helditemid2), except it applies to the currently rendered item/armor instead of the held item.
+Using `uniform int currentRenderedItemId;`, you can detect items and armor rendered in the level at the point of render (based on [`item.properties`](/reference/miscellaneous/item_properties) for items and armour, and [`block.properties`](/reference/miscellaneous/block_properties) for block items). This is similar to [`heldItemId`](/reference/uniforms/general/helditemid) and [`heldItemId2`](/reference/uniforms/general/helditemid2), except it applies to the currently rendered item/armor instead of the held item.
 
 There are some new ID's that can be detected alongside items and armor:
 


### PR DESCRIPTION
Beta Iris 1.8 additions:
- ssbo file initializer (I also reformatted the ssbo docs a bit)
- new shadow programs
- `sky`
- `stars`

Also added `shadowFarPlane` and `shadowNearPlane` as those were missing (I didn't realize till today they even worked outside DH).
Also updated `IRIS_VERSION`