### PR TITLE
mod: custom textures: Added dynamic/atlas details, reformated

### DIFF
--- a/src/content/docs/reference/Buffers/custom_textures.mdx
+++ b/src/content/docs/reference/Buffers/custom_textures.mdx
@@ -8,50 +8,77 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 
-### `texture.<stage>.<bufferName> = <path>`
-This directive allows a custom texture to be bound to an existing sampler (such as a [colortex](/reference/buffers/colortex) sampler). This allows the shader to access external textures or specific textures from the resource pack.
+Iris/Optifine allows binding a texture to an existing sampler (such as a [colortex](/reference/buffers/colortex) sampler). This allows the shader to access images/data included with the shader pack, textures from the resource pack / game files, atlas textures, and more. The following directive can be put in the [shaders.properties](/reference/shadersproperties/overview) file to set up a custom texture:
 
-Textures can be loaded from the shader pack files by replacing `<path>` with the file path to the texture relative to the `shaders` folder. For example `texture.composite.colortex5 = textures/perlin.png` would load `perlin.png` from the `shaders/textures` folder. Iris supports only `.png` image format, whereas Optifine supports `.png` and `.jpg` formats.
+```properties title="shaders.properties"
+texture.<stage>.<bufferName> = <path>
+```
 
+### Texture Types
+Optifine/Iris support four different texture types, which are specified in the `<path>` parameter.
+
+#### Images from Shader Files
+Image files can be loaded from the shader pack files by replacing `<path>` with the file path to the image relative to the `shaders` folder. For example `texture.composite.colortex5 = textures/perlin.png` would load `perlin.png` from the `shaders/textures` folder. Iris supports only `.png` image format, whereas Optifine supports `.png` and `.jpg` formats.
+
+#### Textures from Game Files / Resource Packs
 Textures can also be loaded from the resource pack by replacing `<path>` with `minecraft:` followed by the path in the resource pack (or vanilla files) of the texture. For example, `texture.deferred.colortex7 = minecraft:textures/block/dirt.png` will load the dirt texture from the resource pack or vanilla assets.
 
-Finally, dynamic textures can be loaded, such as the lightmap and texture atlases. For example, the lightmap can be loaded with `texture.prepare.colortex2 = minecraft:dynamic/lightmap_1`, and the texture atlas can be loaded with `texture.composite.colortex9 = minecraft:textures/atlas/blocks.png`.
+#### Atlas and Dynamic Textures
+Atlas textures (such as the block atlas) can be loaded by passing their file path, starting with `minecraft:textures/atlas/`. For example, `texture.composite.colortex9 = minecraft:textures/atlas/blocks.png` loads the block atlas into `colortex9`. A list of available texture atlases can be found in the [Minecraft Wiki](https://minecraft.wiki/w/Texture_atlas#Navigation) under "Procedurally-generated" in the Navigation table.
 
-For any resource pack or atlas texture, the normal or specular versions of the textures (if they exist) can be loaded by appending the `_n` or `_s` suffix respectively. For example, `texture.deferred.colortex2 = minecraft:textures/atlas/blocks_s.png` loads the specular block atlas.
+Additionally, the lightmap dynamic texture can be loaded using either `minecraft:dynamic/lightmap_1` or `minecraft:dynamic/light_map_1`. This texture is equivalent to the `lightmap` sampler used in [gbuffers](/reference/programs/gbuffers). For example `texture.prepare.colortex2 = minecraft:dynamic/lightmap_1` loads the lightmap into `colortex2`. 
 
-Replace `<stage>` with the stage of programs which the texture will be bound in. During that stage, the [colortex](/reference/buffers/colortex) sampler specified with `<bufferName>` will sample the custom texture rather than the [colortex](/reference/buffers/colortex) buffer. The following options are available for `<stage>`:
+#### Raw Textures
+Raw textures can be loaded from the shader files, similarly to image files. However raw textures are uncompressed binary files, where the bytes represent the values in the texture directly. Raw files can also encode 3D textures, and the texture format can be directly controlled (images are always loaded as RGBA8). To use a raw texture, add the following parameters to the custom texture directive:
 
-| name         | description                                                                                     |
-|--------------|-------------------------------------------------------------------------------------------------|
-| `setup`      | [`setup`](/reference/prorgams/setup) programs, exclusive to Iris                                |
-| `begin`      | [`begin`](/reference/programs/begin) programs, exclusive to Iris                                |
-| `shadowcomp` | [`shadowcomp`](/reference/programs/shadow_comp) programs                                        |
-| `prepare`    | [`prepare`](/reference/programs/prepare) programs                                               |
-| `gbuffers`   |  [`gbuffers`](/reference/programs/gbuffers) and [`shadow`](/reference/programs/shadow) programs |
-| `deferred`   | [`deferred`](/reference/programs/deferred) programs                                             |
-| `composite`  | [`composite`](/reference/programs/composite) and [`final`](/reference/programs/final) programs  |
-
-
-# Raw Textures
-### `texture.<stage>.<bufferName> = <path> <type> <internalFormat> <dimensions> <pixelFormat> <pixelType>`
-Raw textures (i.e. unencoded binary files) can also be loaded using the above syntax.
-- `<type>` can be one of the following: `TEXTURE_1D`, `TEXTURE_2D`, `TEXTURE_3D`, or `TEXTURE_RECTANGLE`.
+```properties  title="shaders.properties" ins="<type> <internalFormat> <dimensions> <pixelFormat> <pixelType>"
+texture.<stage>.<bufferName> = <path> <type> <internalFormat> <dimensions> <pixelFormat> <pixelType>
+```
+- Replaec `<type>` with one of the following: `TEXTURE_1D`, `TEXTURE_2D`, `TEXTURE_3D`, or `TEXTURE_RECTANGLE`.
 - Replace `<internalFormat>` with the [texture format](/reference/buffers/texture_format).
 - Replace `<dimensions>` with the fixed size dimensions of the texture (the number of components depends on the type).
 - Replace `<pixelFormat>` with the pixel format described in the "Pixel Formats" section of the [texture format section](/reference/buffers/texture_format).
 - Replace `<pixelType>` with the pixel type described in the "Pixel Types" section of the [texture format section](/reference/buffers/texture_format).
 
 
-# Iris Enhanced Custom Textures
-### `customTexture.<name> = <path>`
-### `customTexture.<name> = <path> <type> <internalFormat> <dimensions> <pixelFormat> <pixelType>`
+### PBR textures
+For any resource pack or atlas texture, the normal or specular versions of the textures (if they exist) can be loaded by appending the `_n` or `_s` suffix respectively. For example, `texture.deferred.colortex2 = minecraft:textures/atlas/blocks_s.png` loads the specular block atlas.
+
+
+### Stage binding
+The Optifine spec for custom textures overwrites the binding of an existing sampler with the new texture. This means the texture originally in the sampler is no longer accessible. Iris adds [Iris Enhanced Custom Textures](#iris-enhanced-custom-textures) which creates a new sampler, thus avoiding this issue.
+
+When using the Optifine spec, replace `<stage>` with the stage of programs which the texture will be bound in. During that stage, the sampler specified with `<bufferName>` will sample the custom texture rather than it original texture. The following options are available for `<stage>`:
+
+| name         | description                                                                                    |
+|--------------|----------------------------------------------------------------------------------------------- |
+| `setup`      | [`setup`](/reference/prorgams/setup) programs, exclusive to Iris                               |
+| `begin`      | [`begin`](/reference/programs/begin) programs, exclusive to Iris                               |
+| `shadowcomp` | [`shadowcomp`](/reference/programs/shadow_comp) programs                                       |
+| `prepare`    | [`prepare`](/reference/programs/prepare) programs                                              |
+| `gbuffers`   | [`gbuffers`](/reference/programs/gbuffers) and [`shadow`](/reference/programs/shadow) programs |
+| `deferred`   | [`deferred`](/reference/programs/deferred) programs                                            |
+| `composite`  | [`composite`](/reference/programs/composite) and [`final`](/reference/programs/final) programs |
+
+
+## Iris Enhanced Custom Textures
 Iris adds support for the `customTexture` directive, which allows the shader dev to use a different sampler instead of overriding an existing sampler. This allows creation of a sampler of (mostly) any name, which replaces `<name>` in the directive and is used in the shader code. Otherwise the syntax of the enhanced custom textures are identical to standard custom textures.
 
+```properties title="shaders.properties"
+customTexture.<name> = <path>
+customTexture.<name> = <path> <type> <internalFormat> <dimensions> <pixelFormat> <pixelType>
+```
 
-# .mcmeta File
+```glsl title="shader code"
+uniform sampler2D <name>;
+uniform sampler<dimensions> <name>; // Raw textures may create sampler1D, sampler2D, sampler3D, or sampler2DRect
+```
+
+
+## .mcmeta File
 Hardware bilinear filtering and wrapping/clamping behavior can be controlled with a `.mcmeta` file with the same filename as the texture with `.mcmeta` appended (for example `perlinNoise.png.mcmeta`). The mcmeta file should be located in the same folder as the texture itself. The syntax is as follows:
 
-```json
+```json title=".mcmeta file"
 {
   "texture":
   {


### PR DESCRIPTION
Updated Custom Textures:
- Added wiki link containing all atlas textures
- Added light_map_1
- Added description to Raw textures and other sections
- Added more headers to make it easier to read/look at
- Updated code block formatting