### PR TITLE
fix: Miscellaneous: move cape ids to item.properties where they belong

### DIFF
--- a/src/content/docs/current/Reference/Miscellaneous/entity_properties.mdx
+++ b/src/content/docs/current/Reference/Miscellaneous/entity_properties.mdx
@@ -24,7 +24,5 @@ The following IDs do not exist in Minecraft but are hardcoded by Iris:
 - `minecraft:entity_shadow`: The circular shadow under an entity when there is no shadow map.
 - `minecraft:entity_flame`: The flame when an entity is on fire.
 - `minecraft:zombie_villager_converting`: A zombie villager undergoing conversion.
-- `minecraft:player_cape`: Player cape (without elytra).
-- `minecraft:elytra_with_cape`: Player cape (with elytra).
 - `minecraft:current_player`: The current player only.
 - `minecraft:end_crystal_beam`: The end crystal healing beams at the ender dragon fight

--- a/src/content/docs/current/Reference/Miscellaneous/item_properties.mdx
+++ b/src/content/docs/current/Reference/Miscellaneous/item_properties.mdx
@@ -21,4 +21,8 @@ item.3 = minecraft:iron_helmet minecraft:trim_lapis
 
 The optional namespace allows support for modded items. Multiple items can be assigned to a single ID, however a single item can only be assigned to a single ID. IDs are stored internally as 16-bit unsigned integers, and can store values between `0` and `65535`.
 
-Armor trim can be assigned with `trim_<material>`, for example `trim_emerald`.
+### Hardcoded IDs
+The following IDs do not exist in Minecraft but are hardcoded by Iris:
+- Armor trim can be assigned with `trim_<material>`, for example `trim_emerald`.
+- `minecraft:player_cape`: Player cape (without elytra).
+- `minecraft:elytra_with_cape`: Player cape (with elytra).


### PR DESCRIPTION
IMS wrongly put them into the wrong category in the old docs.
cape/elytras use the `currentRenderedItemId` when rendering an entity