### PR TITLE
fix: First Shaderpack: reversed values on shadows page

### DIFF
--- a/src/content/docs/current/Guides/Your First Shaderpack/4_shadows.mdx
+++ b/src/content/docs/current/Guides/Your First Shaderpack/4_shadows.mdx
@@ -352,9 +352,9 @@ First, we should define how widely we want to sample, and how we want to distrib
 
 ```glsl
 // defines the total radius in which we sample (in pixels)
-#define SHADOW_RADIUS 4
+#define SHADOW_RADIUS 1
 // controls how many samples we take for every pixel we sample
-#define SHADOW_RANGE 1
+#define SHADOW_RANGE 4
 ```
 
 :::note[Note]


### PR DESCRIPTION
The values in the example are actually reversed. The source code defines them as
```glsl
#define SHADOW_RADIUS 1
#define SHADOW_RANGE 4
```
(Which is the way it also works correctly).

But the guide gets them in the reverse order
```glsl
#define SHADOW_RADIUS 4
#define SHADOW_RANGE 1
```

This PR fixes that.