### PR TITLE
fix: First Shaderpack: missing gamma correction in fog page

### DIFF
--- a/src/content/docs/current/Guides/Your First Shaderpack/5_fog.mdx
+++ b/src/content/docs/current/Guides/Your First Shaderpack/5_fog.mdx
@@ -106,7 +106,7 @@ We can then update our fog blending to make use of this value.
 float dist = length(viewPos) / far;
 float fogFactor = exp(-FOG_DENSITY * (1.0 - dist));
 
-color.rgb = mix(color.rgb, fogColor, clamp(fogFactor, 0.0, 1.0));
+color.rgb = mix(color.rgb, pow(fogColor, vec3(2.2)), clamp(fogFactor, 0.0, 1.0));
 ```
 
 :::caution[Warning]


### PR DESCRIPTION
The current page for the fog shows an example at the end with exponential fog, where the color value seems to have not been gamma corrected, eventhough the reference source code contains it.
```glsl
float dist = length(viewPos) / far;
float fogFactor = exp(-FOG_DENSITY * (1.0 - dist));

color.rgb = mix(color.rgb, fogColor, clamp(fogFactor, 0.0, 1.0));
```

This PR fixes it by gamma-correcting the fog color to match the source material.
```glsl
float dist = length(viewPos) / far;
float fogFactor = exp(-FOG_DENSITY * (1.0 - dist));

color.rgb = mix(color.rgb, pow(fogColor, vec3(2.2)), clamp(fogFactor, 0.0, 1.0));
```
