### PR TITLE
Rename uniform for block selection position

### DIFF
--- a/src/content/docs/current/Reference/Uniforms/id.mdx
+++ b/src/content/docs/current/Reference/Uniforms/id.mdx
@@ -54,7 +54,7 @@ This uniform stores the ID (from [`block.properties`](/current/reference/miscell
 
 ## currentSelectedBlockPos <Badge text="Iris Exclusive" variant="tip" size="medium" />
 ```glsl
-uniform vec3 currentSelectedBlockId;
+uniform vec3 currentSelectedBlockPos;
 ```
 This uniform stores the player space position of the center of the block selected by the player (with the block outline). If no block is selected, the values of all components will be `-256.0`.
 


### PR DESCRIPTION
Renamed incorrect uniform from 'currentSelectedBlockId' to 'currentSelectedBlockPos'