### PR TITLE
Update description for endFlashShadows feature

### DIFF
--- a/src/content/docs/current/Reference/Shaders.Properties/features.mdx
+++ b/src/content/docs/current/Reference/Shaders.Properties/features.mdx
@@ -135,4 +135,4 @@ This directive requires an Iris version supporting [`CAN_DISABLE_WEATHER`](/curr
 endFlashShadows=<true|false>
 ```
 
-If enabled, shadows in the End will be projected from the End flashes instead of a random point in the sky. [`shadowLightPosition`](/current/reference/uniforms/world/#shadowlightposition) will also be set equal to [`endFlashPosition`](/current/reference/uniforms/world/#endflashposition).
+If enabled, shadows in the End will be projected from the End flashes, which were added in 1.21.9, instead of a random point in the sky. [`shadowLightPosition`](/current/reference/uniforms/world/#shadowlightposition) will also be set equal to [`endFlashPosition`](/current/reference/uniforms/world/#endflashposition).


### PR DESCRIPTION
Clarified that End flashes were added in version 1.21.9 for shader devs using older versions